### PR TITLE
feat(sparql): add support for sparql constraints

### DIFF
--- a/src/ir/meta-model/core-constraints.ts
+++ b/src/ir/meta-model/core-constraints.ts
@@ -1,4 +1,5 @@
 import { NodeKind } from './node-kind';
+import { SparqlConstraint } from './sparql-constraint';
 
 export interface CoreConstraints {
   property?: string[];
@@ -38,4 +39,5 @@ export interface CoreConstraints {
   defaultValue?: string;
   order?: number | string;
   flags?: string;
+  sparqlConstraints?: SparqlConstraint[];
 }

--- a/src/ir/meta-model/sparql-constraint.ts
+++ b/src/ir/meta-model/sparql-constraint.ts
@@ -1,0 +1,5 @@
+export interface SparqlConstraint {
+  message?: string;
+  select?: string;
+  ask?: string;
+}

--- a/src/ir/shape-builder.ts
+++ b/src/ir/shape-builder.ts
@@ -13,6 +13,7 @@ import isBlankNode = Util.isBlankNode;
 export class ShapeBuilder {
   private readonly resolved = new Map<string, ShapeDefinition>();
   private readonly termCache = new Map<string, Term>();
+  private readonly sparqlConstraintNodes = new Set<string>();
 
   constructor(
     private readonly shaclDocument: ShaclDocument,
@@ -26,6 +27,12 @@ export class ShapeBuilder {
 
   build(): ShapeDefinition[] {
     const { quads, shapes } = this.index;
+
+    [...quads.keys()].forEach((subject) => {
+      if (this.isSparqlConstraintNode(quads.get(subject) ?? [])) {
+        this.sparqlConstraintNodes.add(subject.value);
+      }
+    });
 
     [...quads.keys()].forEach((subject) => {
       this.buildAndRegisterShape(subject, quads.get(subject) ?? []);
@@ -43,6 +50,12 @@ export class ShapeBuilder {
 
   private getCanonicalTerm(term: Term): Term {
     return this.termCache.get(term.value) ?? term;
+  }
+
+  private isSparqlConstraintNode(quads: Quad[]): boolean {
+    return quads.some(
+      (q) => q.predicate.value.endsWith('select') || q.predicate.value.endsWith('ask')
+    );
   }
 
   private buildAndRegisterShape(subject: Term, quads: Quad[]): void {
@@ -64,10 +77,32 @@ export class ShapeBuilder {
       throw new Error(`Shape '${subject.value}' was not created in first pass`);
     }
 
-    shapeDefinition.dependentShapes = [...(dependencies.get(canonicalSubject) ?? new Set())]
-      .filter((dep) => !(dep.value in lists))
-      .map((dep) => this.resolved.get(dep.value))
-      .filter((shape) => shape !== undefined);
+    const deps = [...(dependencies.get(canonicalSubject) ?? new Set())].filter(
+      (dep) => !(dep.value in lists)
+    );
+
+    const sparqlConstraints: ShapeDefinition[] = [];
+
+    deps.forEach((dep) => {
+      const depShape = this.resolved.get(dep.value);
+      if (depShape) {
+        if (this.sparqlConstraintNodes.has(dep.value)) sparqlConstraints.push(depShape);
+        else {
+          shapeDefinition.dependentShapes ??= [];
+          shapeDefinition.dependentShapes.push(depShape);
+        }
+      }
+    });
+
+    sparqlConstraints.forEach((constraintDef) => {
+      if (constraintDef.coreConstraints?.sparqlConstraints) {
+        shapeDefinition.coreConstraints ??= {};
+        shapeDefinition.coreConstraints.sparqlConstraints ??= [];
+        shapeDefinition.coreConstraints.sparqlConstraints.push(
+          ...constraintDef.coreConstraints.sparqlConstraints
+        );
+      }
+    });
 
     // Handle property shape type override for blank nodes
     const isBlankNode = blanks.some((blank) => blank.value === subject.value);
@@ -92,7 +127,13 @@ export class ShapeBuilder {
     const builder = new ShapeDefinitionBuilder(nodeKey);
     builder.setTargets(getTarget(this.index.targets, nodeKey));
 
+    // Mark if this is a SPARQL constraint node
+    if (this.sparqlConstraintNodes.has(nodeKey)) {
+      builder.markAsSparqlConstraintNode();
+    }
+
     const lists = this.shaclDocument.lists;
+    const isSparqlConstraint = this.sparqlConstraintNodes.has(nodeKey);
     quads.forEach((quad) => {
       const predicate = quad.predicate.value;
       const object = quad.object.value;
@@ -107,7 +148,13 @@ export class ShapeBuilder {
         .with(P.string.endsWith('targetObjectsOf'), () => builder.setTargetObjectsOf(object))
         .with(P.string.endsWith('targetSubjectsOf'), () => builder.setTargetSubjectsOf(object))
         .with(P.string.endsWith('deactivated'), () => builder.setDeactivated(object))
-        .with(P.string.endsWith('message'), () => builder.setMessage(object))
+        .with(P.string.endsWith('message'), () => {
+          if (isSparqlConstraint) {
+            builder.setSparqlMessage(object);
+          } else {
+            builder.setMessage(object);
+          }
+        })
         .with(P.string.endsWith('severity'), () => builder.setSeverity(object))
         .with(P.string.endsWith('pattern'), () => builder.setPattern(object))
         .with(P.string.endsWith('class'), () => builder.setClass(object))
@@ -147,6 +194,9 @@ export class ShapeBuilder {
         .with(P.string.endsWith('disjoint'), () => builder.setDisjoint(object, lists))
         .with(P.string.endsWith('order'), () => builder.setOrder(object))
         .with(P.string.endsWith('flags'), () => builder.setFlags(object))
+        .with(P.string.endsWith('sparql'), () => builder.setSparqlConstraint(object))
+        .with(P.string.endsWith('select'), () => builder.setSparqlSelect(object))
+        .with(P.string.endsWith('ask'), () => builder.setSparqlAsk(object))
         .otherwise(() => {
           // Capture non-SHACL predicates as additional properties
           builder.setAdditionalProperty(predicate, quad.object);

--- a/src/ir/shape-definition-builder.ts
+++ b/src/ir/shape-definition-builder.ts
@@ -5,6 +5,7 @@ import logger from '../logger';
 import { NodeKind } from './meta-model/node-kind';
 import { AdditionalProperty, ShapeDefinition } from './meta-model/shape-definition';
 import type { Term } from 'n3';
+import { SparqlConstraint } from './meta-model/sparql-constraint';
 
 export class ShapeDefinitionBuilder {
   private readonly nodeKey: string;
@@ -13,6 +14,9 @@ export class ShapeDefinitionBuilder {
   private coreConstraints: Partial<CoreConstraints> = {};
   private dependentShapeDefinitions: ShapeDefinition[] = [];
   private readonly additionalProperties: AdditionalProperty[] = [];
+  private sparqlConstraintBlankNodes: string[] = [];
+  private currentSparqlConstraint: Partial<SparqlConstraint> = {};
+  private isSparqlConstraintNode = false;
 
   constructor(nodeKey: string) {
     this.nodeKey = nodeKey;
@@ -330,6 +334,12 @@ export class ShapeDefinitionBuilder {
     // Default if not found yet
     this.shape.type ??= SHAPE_TYPE.NODE_SHAPE;
 
+    // If this is a SPARQL constraint node, add the constraint to coreConstraints
+    if (this.isSparqlConstraintNode && Object.keys(this.currentSparqlConstraint).length > 0) {
+      this.coreConstraints.sparqlConstraints ??= [];
+      this.coreConstraints.sparqlConstraints.push(this.currentSparqlConstraint as SparqlConstraint);
+    }
+
     return {
       nodeKey: this.nodeKey,
       targets: this.targets,
@@ -390,6 +400,58 @@ export class ShapeDefinitionBuilder {
     this.coreConstraints.flags = flags;
     return this;
   }
+
+  // SPARQL constraint methods
+  setSparqlConstraint(blankNodeId: string) {
+    // Track blank node that contains SPARQL constraint
+    this.sparqlConstraintBlankNodes.push(blankNodeId);
+    return this;
+  }
+
+  markAsSparqlConstraintNode() {
+    // Mark this builder as constructing a SPARQL constraint node
+    this.isSparqlConstraintNode = true;
+    return this;
+  }
+
+  setSparqlMessage(message: string) {
+    if (this.isSparqlConstraintNode) {
+      this.currentSparqlConstraint.message = message;
+    }
+    return this;
+  }
+
+  setSparqlSelect(query: string) {
+    if (this.isSparqlConstraintNode) {
+      this.currentSparqlConstraint.select = query;
+    }
+    return this;
+  }
+
+  setSparqlAsk(query: string) {
+    if (this.isSparqlConstraintNode) {
+      this.currentSparqlConstraint.ask = query;
+    }
+    return this;
+  }
+
+  buildSparqlConstraint(): SparqlConstraint | null {
+    if (!this.isSparqlConstraintNode) {
+      return null;
+    }
+    return this.currentSparqlConstraint as SparqlConstraint;
+  }
+
+  addSparqlConstraint(constraint: SparqlConstraint) {
+    this.coreConstraints.sparqlConstraints ??= [];
+    this.coreConstraints.sparqlConstraints.push(constraint);
+    return this;
+  }
+
+  getSparqlConstraintBlankNodes(): string[] {
+    return this.sparqlConstraintBlankNodes;
+  }
+
   /**
    * Extracts values from an RDF list if the identifier is a list head.
    * Otherwise returns the identifier as a single-element array.

--- a/src/json-schema/converters/constraints/constraint-converter.ts
+++ b/src/json-schema/converters/constraints/constraint-converter.ts
@@ -543,6 +543,22 @@ export class ConstraintConverter {
             .ifSatisfied(() => builder.additionalProperties(false))
             .execute();
         })
+        .with('sparqlConstraints', () => {
+          new Condition()
+            .on({
+              key: 'sparqlConstraints',
+              context: this.context,
+              constraints: this.constraints,
+            } as ConstraintCandidate)
+            .must(isNotNull)
+            .ifSatisfied((candidate: ConstraintCandidate) => {
+              const sparqlConstraints = candidate.constraints.sparqlConstraints;
+              if (sparqlConstraints && sparqlConstraints.length > 0) {
+                builder.customProperty(`${PREFIX}-sparql`, sparqlConstraints);
+              }
+            })
+            .execute();
+        })
         .otherwise((key) => {
           if (key == 'property') return;
           new Condition()

--- a/src/json-schema/ir-schema-converter.sparql.test.ts
+++ b/src/json-schema/ir-schema-converter.sparql.test.ts
@@ -1,0 +1,1331 @@
+import {
+  IntermediateRepresentation,
+  IntermediateRepresentationBuilder,
+} from '../ir/intermediate-representation-builder';
+import { ShaclParser } from '../shacl/shacl-parser';
+import { IrSchemaConverter } from './ir-schema-converter';
+
+async function getIr(content: string): Promise<IntermediateRepresentation> {
+  const shaclDocument = await new ShaclParser().withContent(content).parse();
+  return new IntermediateRepresentationBuilder(shaclDocument).build();
+}
+
+describe('SPARQL Constraints in SHACL', () => {
+  describe('Basic SPARQL Constraints', () => {
+    it('should handle shape with both standard constraints and SPARQL SELECT query', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:PersonShape
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [
+                sh:path ex:name ;
+                sh:datatype xsd:string ;
+                sh:minLength 1 ;
+                sh:maxLength 100 ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:email ;
+                sh:datatype xsd:string ;
+                sh:pattern "^[\\\\w.-]+@[\\\\w.-]+\\\\.[\\\\w]+$" ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:sparql [
+                sh:message "Person must have a unique email" ;
+                sh:select """
+                    SELECT $this ?email
+                    WHERE {
+                        $this ex:email ?email .
+                        FILTER EXISTS {
+                            ?other ex:email ?email .
+                            FILTER (?other != $this)
+                        }
+                    }
+                """ ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      // Standard constraints should be converted, SPARQL preserved as extension
+      expect(schema).toStrictEqual({
+        $defs: {
+          Person: {
+            type: 'object',
+            title: 'Person',
+            additionalProperties: true,
+            properties: {
+              name: {
+                type: 'string',
+                minLength: 1,
+                maxLength: 100,
+              },
+              email: {
+                type: 'string',
+                pattern: '^[\\w.-]+@[\\w.-]+\\.[\\w]+$',
+              },
+            },
+            required: ['name', 'email'],
+            'x-shacl-sparql': [
+              {
+                message: 'Person must have a unique email',
+                select: `
+                    SELECT $this ?email
+                    WHERE {
+                        $this ex:email ?email .
+                        FILTER EXISTS {
+                            ?other ex:email ?email .
+                            FILTER (?other != $this)
+                        }
+                    }
+                `,
+              },
+            ],
+          },
+        },
+        $id: 'http://example.org/PersonShape',
+        $ref: '#/$defs/Person',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+
+    it('should handle SPARQL ASK query for age and birthdate consistency', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:PersonShape
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [
+                sh:path ex:name ;
+                sh:datatype xsd:string ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:age ;
+                sh:datatype xsd:integer ;
+                sh:minInclusive 0 ;
+                sh:maxInclusive 150 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:birthDate ;
+                sh:datatype xsd:date ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:sparql [
+                sh:message "Age must be consistent with birthdate" ;
+                sh:ask """
+                    ASK {
+                        $this ex:age ?age ;
+                              ex:birthDate ?birthDate .
+                        BIND(YEAR(NOW()) - YEAR(?birthDate) AS ?calculatedAge)
+                        FILTER(?age != ?calculatedAge)
+                    }
+                """ ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          Person: {
+            type: 'object',
+            title: 'Person',
+            additionalProperties: true,
+            properties: {
+              name: {
+                type: 'string',
+              },
+              age: {
+                type: 'integer',
+                minimum: 0,
+                maximum: 150,
+              },
+              birthDate: {
+                type: 'string',
+                format: 'date',
+              },
+            },
+            required: ['name'],
+            'x-shacl-sparql': [
+              {
+                message: 'Age must be consistent with birthdate',
+                ask: `
+                    ASK {
+                        $this ex:age ?age ;
+                              ex:birthDate ?birthDate .
+                        BIND(YEAR(NOW()) - YEAR(?birthDate) AS ?calculatedAge)
+                        FILTER(?age != ?calculatedAge)
+                    }
+                `,
+              },
+            ],
+          },
+        },
+        $id: 'http://example.org/PersonShape',
+        $ref: '#/$defs/Person',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+
+    it('should handle multiple SPARQL constraints on same shape', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:ProductShape
+            a sh:NodeShape ;
+            sh:targetClass ex:Product ;
+            sh:property [
+                sh:path ex:sku ;
+                sh:datatype xsd:string ;
+                sh:pattern "^[A-Z]{3}-[0-9]{6}$" ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:price ;
+                sh:datatype xsd:decimal ;
+                sh:minExclusive 0.0 ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:stock ;
+                sh:datatype xsd:integer ;
+                sh:minInclusive 0 ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:sparql [
+                sh:message "SKU must be unique in catalog" ;
+                sh:select """
+                    SELECT $this WHERE {
+                        $this ex:sku ?sku .
+                        ?other ex:sku ?sku .
+                        FILTER ($this != ?other)
+                    }
+                """ ;
+            ] ;
+            sh:sparql [
+                sh:message "Stock cannot be negative" ;
+                sh:select """
+                    SELECT $this WHERE {
+                        $this ex:stock ?stock .
+                        FILTER (?stock < 0)
+                    }
+                """ ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          Product: {
+            type: 'object',
+            title: 'Product',
+            additionalProperties: true,
+            properties: {
+              sku: {
+                type: 'string',
+                pattern: '^[A-Z]{3}-[0-9]{6}$',
+              },
+              price: {
+                type: 'number',
+                exclusiveMinimum: 0,
+              },
+              stock: {
+                type: 'integer',
+                minimum: 0,
+              },
+            },
+            required: ['sku', 'price', 'stock'],
+            'x-shacl-sparql': [
+              {
+                message: 'SKU must be unique in catalog',
+                select: `
+                    SELECT $this WHERE {
+                        $this ex:sku ?sku .
+                        ?other ex:sku ?sku .
+                        FILTER ($this != ?other)
+                    }
+                `,
+              },
+              {
+                message: 'Stock cannot be negative',
+                select: `
+                    SELECT $this WHERE {
+                        $this ex:stock ?stock .
+                        FILTER (?stock < 0)
+                    }
+                `,
+              },
+            ],
+          },
+        },
+        $id: 'http://example.org/ProductShape',
+        $ref: '#/$defs/Product',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+  });
+
+  describe('Property-level SPARQL Constraints', () => {
+    it('should handle SPARQL constraint on property shape', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:UserShape
+            a sh:NodeShape ;
+            sh:targetClass ex:User ;
+            sh:property [
+                sh:path ex:username ;
+                sh:datatype xsd:string ;
+                sh:minLength 3 ;
+                sh:maxLength 20 ;
+                sh:pattern "^[a-zA-Z0-9_]+$" ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:email ;
+                sh:datatype xsd:string ;
+                sh:pattern "^[\\\\w.-]+@[\\\\w.-]+\\\\.[\\\\w]+$" ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+                sh:sparql [
+                    sh:message "Email must be unique in the system" ;
+                    sh:select """
+                        SELECT $this ?email
+                        WHERE {
+                            $this ex:email ?email .
+                            ?other ex:email ?email .
+                            FILTER ($this != ?other)
+                        }
+                    """ ;
+                ] ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          User: {
+            type: 'object',
+            title: 'User',
+            additionalProperties: true,
+            properties: {
+              username: {
+                type: 'string',
+                minLength: 3,
+                maxLength: 20,
+                pattern: '^[a-zA-Z0-9_]+$',
+              },
+              email: {
+                type: 'string',
+                pattern: '^[\\w.-]+@[\\w.-]+\\.[\\w]+$',
+                'x-shacl-sparql': [
+                  {
+                    message: 'Email must be unique in the system',
+                    select:
+                      '\n                        SELECT $this ?email\n                        WHERE {\n                            $this ex:email ?email .\n                            ?other ex:email ?email .\n                            FILTER ($this != ?other)\n                        }\n                    ',
+                  },
+                ],
+              },
+            },
+            required: ['username', 'email'],
+          },
+        },
+        $id: 'http://example.org/UserShape',
+        $ref: '#/$defs/User',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+  });
+
+  describe('Complex SPARQL Validation Rules', () => {
+    it('should handle SPARQL constraint with aggregation for team size', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:TeamShape
+            a sh:NodeShape ;
+            sh:targetClass ex:Team ;
+            sh:property [
+                sh:path ex:name ;
+                sh:datatype xsd:string ;
+                sh:minLength 1 ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:member ;
+                sh:node ex:MemberShape ;
+            ] ;
+            sh:sparql [
+                sh:message "Team must have at least 5 members" ;
+                sh:select """
+                    SELECT $this (COUNT(?member) AS ?count)
+                    WHERE {
+                        $this ex:member ?member .
+                    }
+                    GROUP BY $this
+                    HAVING (COUNT(?member) < 5)
+                """ ;
+            ] .
+
+        ex:MemberShape
+            a sh:NodeShape ;
+            sh:property [
+                sh:path ex:memberId ;
+                sh:datatype xsd:string ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:memberName ;
+                sh:datatype xsd:string ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          Member: {
+            type: 'object',
+            title: 'Member',
+            additionalProperties: true,
+            properties: {
+              memberId: {
+                type: 'string',
+              },
+              memberName: {
+                type: 'string',
+              },
+            },
+            required: ['memberId', 'memberName'],
+          },
+          Team: {
+            type: 'object',
+            title: 'Team',
+            additionalProperties: true,
+            properties: {
+              name: {
+                type: 'string',
+                minLength: 1,
+              },
+              member: {
+                type: 'array',
+                items: {
+                  $ref: '#/$defs/Member',
+                },
+              },
+            },
+            required: ['name'],
+            'x-shacl-sparql': [
+              {
+                message: 'Team must have at least 5 members',
+                select: `
+                    SELECT $this (COUNT(?member) AS ?count)
+                    WHERE {
+                        $this ex:member ?member .
+                    }
+                    GROUP BY $this
+                    HAVING (COUNT(?member) < 5)
+                `,
+              },
+            ],
+          },
+        },
+        $id: 'http://example.org/TeamShape',
+        $ref: '#/$defs/Team',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+
+    it('should handle SPARQL constraint with OPTIONAL patterns for conditional validation', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:PersonShape
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [
+                sh:path ex:name ;
+                sh:datatype xsd:string ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:address ;
+                sh:node ex:AddressShape ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:sparql [
+                sh:message "If address is provided, it must have a country" ;
+                sh:select """
+                    SELECT $this
+                    WHERE {
+                        $this ex:address ?address .
+                        OPTIONAL { ?address ex:country ?country }
+                        FILTER (!BOUND(?country))
+                    }
+                """ ;
+            ] .
+
+        ex:AddressShape
+            a sh:NodeShape ;
+            sh:property [
+                sh:path ex:street ;
+                sh:datatype xsd:string ;
+                sh:minLength 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:city ;
+                sh:datatype xsd:string ;
+                sh:minLength 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:country ;
+                sh:datatype xsd:string ;
+                sh:minLength 2 ;
+                sh:maxLength 2 ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          Address: {
+            type: 'object',
+            title: 'Address',
+            additionalProperties: true,
+            properties: {
+              street: {
+                type: 'string',
+                minLength: 1,
+              },
+              city: {
+                type: 'string',
+                minLength: 1,
+              },
+              country: {
+                type: 'string',
+                minLength: 2,
+                maxLength: 2,
+              },
+            },
+            required: ['street', 'city', 'country'],
+          },
+          Person: {
+            type: 'object',
+            title: 'Person',
+            additionalProperties: true,
+            properties: {
+              name: {
+                type: 'string',
+              },
+              address: {
+                $ref: '#/$defs/Address',
+              },
+            },
+            required: ['name'],
+            'x-shacl-sparql': [
+              {
+                message: 'If address is provided, it must have a country',
+                select: `
+                    SELECT $this
+                    WHERE {
+                        $this ex:address ?address .
+                        OPTIONAL { ?address ex:country ?country }
+                        FILTER (!BOUND(?country))
+                    }
+                `,
+              },
+            ],
+          },
+        },
+        $id: 'http://example.org/PersonShape',
+        $ref: '#/$defs/Person',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+
+    it('should handle SPARQL constraint validating order total matches line items', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:OrderShape
+            a sh:NodeShape ;
+            sh:targetClass ex:Order ;
+            sh:property [
+                sh:path ex:orderId ;
+                sh:datatype xsd:string ;
+                sh:pattern "^ORD-[0-9]{6}$" ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:total ;
+                sh:datatype xsd:decimal ;
+                sh:minInclusive 0.0 ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:lineItem ;
+                sh:node ex:LineItemShape ;
+                sh:minCount 1 ;
+            ] ;
+            sh:sparql [
+                sh:message "Order total must match sum of line items" ;
+                sh:select """
+                    SELECT $this ?total ?calculatedTotal
+                    WHERE {
+                        $this ex:total ?total ;
+                              ex:lineItem ?item .
+                        {
+                            SELECT $this (SUM(?itemTotal) AS ?calculatedTotal)
+                            WHERE {
+                                $this ex:lineItem ?item .
+                                ?item ex:price ?price ;
+                                      ex:quantity ?qty .
+                                BIND(?price * ?qty AS ?itemTotal)
+                            }
+                            GROUP BY $this
+                        }
+                        FILTER (?total != ?calculatedTotal)
+                    }
+                """ ;
+            ] .
+
+        ex:LineItemShape
+            a sh:NodeShape ;
+            sh:property [
+                sh:path ex:price ;
+                sh:datatype xsd:decimal ;
+                sh:minExclusive 0.0 ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:quantity ;
+                sh:datatype xsd:integer ;
+                sh:minInclusive 1 ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          LineItem: {
+            type: 'object',
+            title: 'LineItem',
+            additionalProperties: true,
+            properties: {
+              price: {
+                type: 'number',
+                exclusiveMinimum: 0,
+              },
+              quantity: {
+                type: 'integer',
+                minimum: 1,
+              },
+            },
+            required: ['price', 'quantity'],
+          },
+          Order: {
+            type: 'object',
+            title: 'Order',
+            additionalProperties: true,
+            properties: {
+              orderId: {
+                type: 'string',
+                pattern: '^ORD-[0-9]{6}$',
+              },
+              total: {
+                type: 'number',
+                minimum: 0,
+              },
+              lineItem: {
+                type: 'array',
+                items: {
+                  $ref: '#/$defs/LineItem',
+                },
+                minItems: 1,
+              },
+            },
+            required: ['orderId', 'total', 'lineItem'],
+            'x-shacl-sparql': [
+              {
+                message: 'Order total must match sum of line items',
+                select: `
+                    SELECT $this ?total ?calculatedTotal
+                    WHERE {
+                        $this ex:total ?total ;
+                              ex:lineItem ?item .
+                        {
+                            SELECT $this (SUM(?itemTotal) AS ?calculatedTotal)
+                            WHERE {
+                                $this ex:lineItem ?item .
+                                ?item ex:price ?price ;
+                                      ex:quantity ?qty .
+                                BIND(?price * ?qty AS ?itemTotal)
+                            }
+                            GROUP BY $this
+                        }
+                        FILTER (?total != ?calculatedTotal)
+                    }
+                `,
+              },
+            ],
+          },
+        },
+        $id: 'http://example.org/OrderShape',
+        $ref: '#/$defs/Order',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+
+    it('should handle SPARQL with UNION patterns for contact validation', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:ContactShape
+            a sh:NodeShape ;
+            sh:targetClass ex:Contact ;
+            sh:property [
+                sh:path ex:name ;
+                sh:datatype xsd:string ;
+                sh:minLength 1 ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:email ;
+                sh:datatype xsd:string ;
+                sh:pattern "^[\\\\w.-]+@[\\\\w.-]+\\\\.[\\\\w]+$" ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:phone ;
+                sh:datatype xsd:string ;
+                sh:pattern "^\\\\+?[1-9]\\\\d{1,14}$" ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:sparql [
+                sh:message "Must have either email or phone" ;
+                sh:select """
+                    SELECT $this
+                    WHERE {
+                        FILTER NOT EXISTS {
+                            { $this ex:email ?email }
+                            UNION
+                            { $this ex:phone ?phone }
+                        }
+                    }
+                """ ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          Contact: {
+            type: 'object',
+            title: 'Contact',
+            additionalProperties: true,
+            properties: {
+              name: {
+                type: 'string',
+                minLength: 1,
+              },
+              email: {
+                type: 'string',
+                pattern: '^[\\w.-]+@[\\w.-]+\\.[\\w]+$',
+              },
+              phone: {
+                type: 'string',
+                pattern: '^\\+?[1-9]\\d{1,14}$',
+              },
+            },
+            required: ['name'],
+            'x-shacl-sparql': [
+              {
+                message: 'Must have either email or phone',
+                select: `
+                    SELECT $this
+                    WHERE {
+                        FILTER NOT EXISTS {
+                            { $this ex:email ?email }
+                            UNION
+                            { $this ex:phone ?phone }
+                        }
+                    }
+                `,
+              },
+            ],
+          },
+        },
+        $id: 'http://example.org/ContactShape',
+        $ref: '#/$defs/Contact',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+  });
+
+  describe('SPARQL Constraints with Data Validation', () => {
+    it('should handle SPARQL validating date ranges', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:EventShape
+            a sh:NodeShape ;
+            sh:targetClass ex:Event ;
+            sh:property [
+                sh:path ex:name ;
+                sh:datatype xsd:string ;
+                sh:minLength 1 ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:startDate ;
+                sh:datatype xsd:date ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:endDate ;
+                sh:datatype xsd:date ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:sparql [
+                sh:message "End date must be after start date" ;
+                sh:select """
+                    SELECT $this ?start ?end
+                    WHERE {
+                        $this ex:startDate ?start ;
+                              ex:endDate ?end .
+                        FILTER (?end <= ?start)
+                    }
+                """ ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          Event: {
+            type: 'object',
+            title: 'Event',
+            additionalProperties: true,
+            properties: {
+              name: {
+                type: 'string',
+                minLength: 1,
+              },
+              startDate: {
+                type: 'string',
+                format: 'date',
+              },
+              endDate: {
+                type: 'string',
+                format: 'date',
+              },
+            },
+            required: ['name', 'startDate', 'endDate'],
+            'x-shacl-sparql': [
+              {
+                message: 'End date must be after start date',
+                select: `
+                    SELECT $this ?start ?end
+                    WHERE {
+                        $this ex:startDate ?start ;
+                              ex:endDate ?end .
+                        FILTER (?end <= ?start)
+                    }
+                `,
+              },
+            ],
+          },
+        },
+        $id: 'http://example.org/EventShape',
+        $ref: '#/$defs/Event',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+
+    it('should handle SPARQL with mathematical operations for area calculation', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:RectangleShape
+            a sh:NodeShape ;
+            sh:targetClass ex:Rectangle ;
+            sh:property [
+                sh:path ex:width ;
+                sh:datatype xsd:decimal ;
+                sh:minExclusive 0.0 ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:height ;
+                sh:datatype xsd:decimal ;
+                sh:minExclusive 0.0 ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:area ;
+                sh:datatype xsd:decimal ;
+                sh:minExclusive 0.0 ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:sparql [
+                sh:message "Area must equal width * height" ;
+                sh:select """
+                    SELECT $this ?area ?width ?height
+                    WHERE {
+                        $this ex:area ?area ;
+                              ex:width ?width ;
+                              ex:height ?height .
+                        FILTER (?area != (?width * ?height))
+                    }
+                """ ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          Rectangle: {
+            type: 'object',
+            title: 'Rectangle',
+            additionalProperties: true,
+            properties: {
+              width: {
+                type: 'number',
+                exclusiveMinimum: 0,
+              },
+              height: {
+                type: 'number',
+                exclusiveMinimum: 0,
+              },
+              area: {
+                type: 'number',
+                exclusiveMinimum: 0,
+              },
+            },
+            required: ['width', 'height', 'area'],
+            'x-shacl-sparql': [
+              {
+                message: 'Area must equal width * height',
+                select: `
+                    SELECT $this ?area ?width ?height
+                    WHERE {
+                        $this ex:area ?area ;
+                              ex:width ?width ;
+                              ex:height ?height .
+                        FILTER (?area != (?width * ?height))
+                    }
+                `,
+              },
+            ],
+          },
+        },
+        $id: 'http://example.org/RectangleShape',
+        $ref: '#/$defs/Rectangle',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+
+    it('should handle SPARQL with string operations for name validation', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:PersonShape
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [
+                sh:path ex:firstName ;
+                sh:datatype xsd:string ;
+                sh:minLength 1 ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:lastName ;
+                sh:datatype xsd:string ;
+                sh:minLength 1 ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:displayName ;
+                sh:datatype xsd:string ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:sparql [
+                sh:message "Display name must be concatenation of first and last name" ;
+                sh:select """
+                    SELECT $this ?displayName ?firstName ?lastName
+                    WHERE {
+                        $this ex:displayName ?displayName ;
+                              ex:firstName ?firstName ;
+                              ex:lastName ?lastName .
+                        BIND(CONCAT(?firstName, " ", ?lastName) AS ?expected)
+                        FILTER (?displayName != ?expected)
+                    }
+                """ ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          Person: {
+            type: 'object',
+            title: 'Person',
+            additionalProperties: true,
+            properties: {
+              firstName: {
+                type: 'string',
+                minLength: 1,
+              },
+              lastName: {
+                type: 'string',
+                minLength: 1,
+              },
+              displayName: {
+                type: 'string',
+              },
+            },
+            required: ['firstName', 'lastName', 'displayName'],
+            'x-shacl-sparql': [
+              {
+                message: 'Display name must be concatenation of first and last name',
+                select: `
+                    SELECT $this ?displayName ?firstName ?lastName
+                    WHERE {
+                        $this ex:displayName ?displayName ;
+                              ex:firstName ?firstName ;
+                              ex:lastName ?lastName .
+                        BIND(CONCAT(?firstName, " ", ?lastName) AS ?expected)
+                        FILTER (?displayName != ?expected)
+                    }
+                `,
+              },
+            ],
+          },
+        },
+        $id: 'http://example.org/PersonShape',
+        $ref: '#/$defs/Person',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+  });
+
+  describe('SPARQL with External References', () => {
+    it('should handle SPARQL checking external resource existence', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:EmployeeShape
+            a sh:NodeShape ;
+            sh:targetClass ex:Employee ;
+            sh:property [
+                sh:path ex:employeeId ;
+                sh:datatype xsd:string ;
+                sh:pattern "^EMP-[0-9]{6}$" ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:name ;
+                sh:datatype xsd:string ;
+                sh:minLength 1 ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:department ;
+                sh:class ex:Department ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:sparql [
+                sh:message "Department reference must exist" ;
+                sh:select """
+                    SELECT $this ?dept
+                    WHERE {
+                        $this ex:department ?dept .
+                        FILTER NOT EXISTS {
+                            ?dept a ex:Department .
+                        }
+                    }
+                """ ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          Employee: {
+            type: 'object',
+            title: 'Employee',
+            additionalProperties: true,
+            properties: {
+              employeeId: {
+                type: 'string',
+                pattern: '^EMP-[0-9]{6}$',
+              },
+              name: {
+                type: 'string',
+                minLength: 1,
+              },
+              department: {
+                $ref: '#/$defs/Department',
+              },
+            },
+            required: ['employeeId', 'name', 'department'],
+            'x-shacl-sparql': [
+              {
+                message: 'Department reference must exist',
+                select: `
+                    SELECT $this ?dept
+                    WHERE {
+                        $this ex:department ?dept .
+                        FILTER NOT EXISTS {
+                            ?dept a ex:Department .
+                        }
+                    }
+                `,
+              },
+            ],
+          },
+        },
+        $id: 'http://example.org/EmployeeShape',
+        $ref: '#/$defs/Employee',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+
+    it('should handle SPARQL with inverse relationship validation', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:ManagerShape
+            a sh:NodeShape ;
+            sh:targetClass ex:Manager ;
+            sh:property [
+                sh:path ex:name ;
+                sh:datatype xsd:string ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:manages ;
+                sh:class ex:Employee ;
+            ] ;
+            sh:sparql [
+                sh:message "If A manages B, then B must have A as manager" ;
+                sh:select """
+                    SELECT $this ?manages
+                    WHERE {
+                        $this ex:manages ?manages .
+                        FILTER NOT EXISTS {
+                            ?manages ex:manager $this .
+                        }
+                    }
+                """ ;
+            ] .
+
+        ex:EmployeeShape
+            a sh:NodeShape ;
+            sh:targetClass ex:Employee ;
+            sh:property [
+                sh:path ex:name ;
+                sh:datatype xsd:string ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] ;
+            sh:property [
+                sh:path ex:manager ;
+                sh:class ex:Manager ;
+                sh:maxCount 1 ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          Employee: {
+            type: 'object',
+            title: 'Employee',
+            additionalProperties: true,
+            properties: {
+              name: {
+                type: 'string',
+              },
+              manager: {
+                $ref: '#/$defs/Manager',
+              },
+            },
+            required: ['name'],
+          },
+          Manager: {
+            type: 'object',
+            title: 'Manager',
+            additionalProperties: true,
+            properties: {
+              name: {
+                type: 'string',
+              },
+              manages: {
+                type: 'array',
+                items: {
+                  $ref: '#/$defs/Employee',
+                },
+              },
+            },
+            required: ['name'],
+            'x-shacl-sparql': [
+              {
+                message: 'If A manages B, then B must have A as manager',
+                select: `
+                    SELECT $this ?manages
+                    WHERE {
+                        $this ex:manages ?manages .
+                        FILTER NOT EXISTS {
+                            ?manages ex:manager $this .
+                        }
+                    }
+                `,
+              },
+            ],
+          },
+        },
+        $id: 'http://example.org/ManagerShape',
+        $ref: '#/$defs/Manager',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Add support for SPARQL constraints.
- sh:select and sh:ask queries will be preserved in the JSON Schema generated under the x-shacl-sparql extension.
- sh:message for the query will be parsed separately.