### PR TITLE
fix(conversion): merge schemas with same targets

### DIFF
--- a/src/ir/target-resolver.ts
+++ b/src/ir/target-resolver.ts
@@ -1,9 +1,6 @@
 import { Quad, Quad_Subject, Term, Util } from 'n3';
 import {
-  RDF_TYPE,
-  SHACL_NODE_SHAPE,
   SHACL_PATH,
-  SHACL_PROPERTY_SHAPE,
   SHACL_TARGET_CLASS,
   SHACL_TARGET_NODE,
   SHACL_TARGET_OBJECTS_OF,
@@ -42,7 +39,6 @@ export class TargetResolver {
         )
       )
     );
-    this.numberDuplicates(targets);
     return targets;
   }
 
@@ -103,46 +99,5 @@ export class TargetResolver {
     return noTargets
       ? [extractStrippedName(subject.value)]
       : [...new Set([...targetClasses, ...targetNodes, ...targetSubjects, ...targetObjects])];
-  }
-
-  private isShaclShape(term: Term): boolean {
-    return this.shaclDocument.store
-      .getQuads(term, RDF_TYPE, null, this.shaclDocument.graphId)
-      .some(
-        (quad) =>
-          quad.object.value === SHACL_NODE_SHAPE || quad.object.value === SHACL_PROPERTY_SHAPE
-      );
-  }
-
-  private numberDuplicates(targets: Map<Term, string[]>) {
-    const shaclShapeTargets = [...targets.entries()]
-      .filter(([term]) => !isBlankNode(term))
-      .filter(([term]) => this.isShaclShape(term));
-
-    // Count how many times each target appears across SHACL shapes only
-    const targetCounts = new Map<string, number>();
-    shaclShapeTargets.forEach(([, targetList]) => {
-      targetList.forEach((target) => {
-        targetCounts.set(target, (targetCounts.get(target) ?? 0) + 1);
-      });
-    });
-
-    // Track current index for each duplicate target
-    const targetIndexes = new Map<string, number>();
-
-    // Update targets with numbers for duplicates (only for SHACL shapes)
-    shaclShapeTargets.forEach(([term, targetList]) => {
-      const numberedTargets = targetList.map((target) => {
-        const count = targetCounts.get(target) ?? 0;
-        if (count > 1) {
-          // This target appears multiple times, assign a number
-          const currentIndex = (targetIndexes.get(target) ?? 0) + 1;
-          targetIndexes.set(target, currentIndex);
-          return `${target}_${String(currentIndex)}`;
-        }
-        return target;
-      });
-      targets.set(term, numberedTargets);
-    });
   }
 }

--- a/src/json-schema/ir-schema-converter.merge-targets.test.ts
+++ b/src/json-schema/ir-schema-converter.merge-targets.test.ts
@@ -10,14 +10,14 @@ async function getIr(content: string): Promise<IntermediateRepresentation> {
   return new IntermediateRepresentationBuilder(shaclDocument).build();
 }
 
-describe('IR Schema Converter - Targets', () => {
-  describe('Base Case', () => {
-    it('should assign numbered targets for same targets', async () => {
+describe('IR Schema Converter - Merge Targets', () => {
+  describe('Basic Merging', () => {
+    it('should merge two shapes with same targetClass into single schema', async () => {
       const content = `
         @prefix sh: <http://www.w3.org/ns/shacl#> .
         @prefix ex: <http://example.org/> .
         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-      
+
       ex:PersonShape
           a sh:NodeShape ;
           sh:targetClass ex:Person ;
@@ -27,46 +27,40 @@ describe('IR Schema Converter - Targets', () => {
               sh:minCount 1 ;
               sh:maxCount 1 ;
           ] .
-          
+
       ex:HumanShape
           a sh:NodeShape ;
           sh:targetClass ex:Person ;
           sh:property [
-              sh:path ex:address ;
-              sh:datatype xsd:string ;
+              sh:path ex:age ;
+              sh:datatype xsd:integer ;
               sh:minCount 1 ;
               sh:maxCount 1 ;
           ] .
       `;
       const ir = await getIr(content);
       const schema = new IrSchemaConverter(ir).convert();
+
+      // Should create a single Person schema with both name and age properties
       expect(schema).toStrictEqual({
         $defs: {
-          Person_1: {
+          Person: {
             additionalProperties: true,
             properties: {
               name: {
                 type: 'string',
               },
-            },
-            required: ['name'],
-            title: 'Person_1',
-            type: 'object',
-          },
-          Person_2: {
-            additionalProperties: true,
-            properties: {
-              address: {
-                type: 'string',
+              age: {
+                type: 'integer',
               },
             },
-            required: ['address'],
-            title: 'Person_2',
+            required: ['name', 'age'],
+            title: 'Person',
             type: 'object',
           },
         },
         $id: 'http://example.org/PersonShape',
-        $ref: '#/$defs/Person_1',
+        $ref: '#/$defs/Person',
         $schema: 'https://json-schema.org/draft/2020-12/schema',
         'x-shacl-prefixes': {
           ex: 'http://example.org/',
@@ -75,10 +69,8 @@ describe('IR Schema Converter - Targets', () => {
         },
       });
     });
-  });
 
-  describe('Multiple Duplicates (3+)', () => {
-    it('should assign sequential numbers for 3+ shapes with same target', async () => {
+    it('should merge three shapes with same targetClass', async () => {
       const content = `
         @prefix sh: <http://www.w3.org/ns/shacl#> .
         @prefix ex: <http://example.org/> .
@@ -113,30 +105,16 @@ describe('IR Schema Converter - Targets', () => {
 
       expect(schema).toStrictEqual({
         $defs: {
-          Person_1: {
-            title: 'Person_1',
+          Person: {
+            title: 'Person',
             type: 'object',
             properties: {
               name: {
                 type: 'string',
               },
-            },
-            additionalProperties: true,
-          },
-          Person_2: {
-            title: 'Person_2',
-            type: 'object',
-            properties: {
               age: {
                 type: 'integer',
               },
-            },
-            additionalProperties: true,
-          },
-          Person_3: {
-            title: 'Person_3',
-            type: 'object',
-            properties: {
               email: {
                 type: 'string',
               },
@@ -145,7 +123,7 @@ describe('IR Schema Converter - Targets', () => {
           },
         },
         $id: 'http://example.org/PersonShape1',
-        $ref: '#/$defs/Person_1',
+        $ref: '#/$defs/Person',
         $schema: 'https://json-schema.org/draft/2020-12/schema',
         'x-shacl-prefixes': {
           sh: 'http://www.w3.org/ns/shacl#',
@@ -156,8 +134,8 @@ describe('IR Schema Converter - Targets', () => {
     });
   });
 
-  describe('Multiple Sets of Duplicates', () => {
-    it('should number each group of duplicates independently', async () => {
+  describe('Multiple Target Groups', () => {
+    it('should merge within groups but keep groups separate', async () => {
       const content = `
         @prefix sh: <http://www.w3.org/ns/shacl#> .
         @prefix ex: <http://example.org/> .
@@ -200,40 +178,26 @@ describe('IR Schema Converter - Targets', () => {
 
       expect(schema).toStrictEqual({
         $defs: {
-          Person_1: {
-            title: 'Person_1',
+          Person: {
+            title: 'Person',
             type: 'object',
             properties: {
               name: {
                 type: 'string',
               },
-            },
-            additionalProperties: true,
-          },
-          Person_2: {
-            title: 'Person_2',
-            type: 'object',
-            properties: {
               age: {
                 type: 'integer',
               },
             },
             additionalProperties: true,
           },
-          Organization_1: {
-            title: 'Organization_1',
+          Organization: {
+            title: 'Organization',
             type: 'object',
             properties: {
               orgName: {
                 type: 'string',
               },
-            },
-            additionalProperties: true,
-          },
-          Organization_2: {
-            title: 'Organization_2',
-            type: 'object',
-            properties: {
               taxId: {
                 type: 'string',
               },
@@ -242,7 +206,7 @@ describe('IR Schema Converter - Targets', () => {
           },
         },
         $id: 'http://example.org/PersonShape1',
-        $ref: '#/$defs/Person_1',
+        $ref: '#/$defs/Person',
         $schema: 'https://json-schema.org/draft/2020-12/schema',
         'x-shacl-prefixes': {
           sh: 'http://www.w3.org/ns/shacl#',
@@ -253,8 +217,57 @@ describe('IR Schema Converter - Targets', () => {
     });
   });
 
-  describe('Mix of Duplicates and Unique Targets', () => {
-    it('should only number duplicate targets, leaving unique ones unchanged', async () => {
+  describe('Required Fields Merging', () => {
+    it('should merge required fields from multiple shapes', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:PersonShape1
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [
+                sh:path ex:name ;
+                sh:datatype xsd:string ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] .
+
+        ex:PersonShape2
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [
+                sh:path ex:email ;
+                sh:datatype xsd:string ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] .
+
+        ex:PersonShape3
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [
+                sh:path ex:age ;
+                sh:datatype xsd:integer ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema.$defs?.Person).toMatchObject({
+        properties: {
+          name: { type: 'string' },
+          email: { type: 'string' },
+          age: { type: 'integer' },
+        },
+        required: ['name', 'email'],
+      });
+    });
+  });
+
+  describe('Mix of Merged and Unique Targets', () => {
+    it('should merge duplicates and leave unique targets unchanged', async () => {
       const content = `
         @prefix sh: <http://www.w3.org/ns/shacl#> .
         @prefix ex: <http://example.org/> .
@@ -297,20 +310,13 @@ describe('IR Schema Converter - Targets', () => {
 
       expect(schema).toStrictEqual({
         $defs: {
-          Person_1: {
-            title: 'Person_1',
+          Person: {
+            title: 'Person',
             type: 'object',
             properties: {
               name: {
                 type: 'string',
               },
-            },
-            additionalProperties: true,
-          },
-          Person_2: {
-            title: 'Person_2',
-            type: 'object',
-            properties: {
               age: {
                 type: 'integer',
               },
@@ -339,7 +345,7 @@ describe('IR Schema Converter - Targets', () => {
           },
         },
         $id: 'http://example.org/PersonShape1',
-        $ref: '#/$defs/Person_1',
+        $ref: '#/$defs/Person',
         $schema: 'https://json-schema.org/draft/2020-12/schema',
         'x-shacl-prefixes': {
           sh: 'http://www.w3.org/ns/shacl#',
@@ -350,8 +356,168 @@ describe('IR Schema Converter - Targets', () => {
     });
   });
 
+  describe('Multiple Targets per Shape', () => {
+    it('should handle shape with multiple targets correctly when merged', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:PersonOrEmployeeShape
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:targetClass ex:Employee ;
+            sh:property [
+                sh:path ex:name ;
+                sh:datatype xsd:string ;
+            ] .
+
+        ex:AnotherPersonShape
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [
+                sh:path ex:age ;
+                sh:datatype xsd:integer ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      // Person should have both name and age (merged)
+      // Employee should have only name (not merged with anything)
+      expect(schema).toStrictEqual({
+        $defs: {
+          Person: {
+            title: 'Person',
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+              },
+              age: {
+                type: 'integer',
+              },
+            },
+            additionalProperties: true,
+          },
+          Employee: {
+            title: 'Employee',
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+              },
+            },
+            additionalProperties: true,
+          },
+        },
+        $id: 'http://example.org/PersonOrEmployeeShape',
+        $ref: '#/$defs/Person',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+  });
+
+  describe('Other Target Types', () => {
+    it('should merge shapes with same targetNode', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:JohnShape1
+            a sh:NodeShape ;
+            sh:targetNode ex:john ;
+            sh:property [
+                sh:path ex:name ;
+                sh:datatype xsd:string ;
+            ] .
+
+        ex:JohnShape2
+            a sh:NodeShape ;
+            sh:targetNode ex:john ;
+            sh:property [
+                sh:path ex:age ;
+                sh:datatype xsd:integer ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          john: {
+            additionalProperties: true,
+            properties: {
+              name: {
+                type: 'string',
+              },
+              age: {
+                type: 'integer',
+              },
+            },
+            title: 'john',
+            type: 'object',
+            'x-shacl-targetNodes': ['http://example.org/john'],
+          },
+        },
+        $id: 'http://example.org/JohnShape1',
+        $ref: '#/$defs/john',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          ex: 'http://example.org/',
+          sh: 'http://www.w3.org/ns/shacl#',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+  });
+
+  describe('Closed Shapes', () => {
+    it('should handle closed constraint when merging shapes', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:PersonShape1
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:closed true ;
+            sh:property [
+                sh:path ex:name ;
+                sh:datatype xsd:string ;
+            ] .
+
+        ex:PersonShape2
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [
+                sh:path ex:age ;
+                sh:datatype xsd:integer ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema.$defs?.Person).toMatchObject({
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'integer' },
+        },
+        // If any shape is closed, the merged shape should be closed
+        additionalProperties: false,
+      });
+    });
+  });
+
   describe('No Duplicates', () => {
-    it('should not number targets when all are unique', async () => {
+    it('should not modify targets when all are unique', async () => {
       const content = `
         @prefix sh: <http://www.w3.org/ns/shacl#> .
         @prefix ex: <http://example.org/> .
@@ -429,78 +595,8 @@ describe('IR Schema Converter - Targets', () => {
     });
   });
 
-  describe('Single Shape with Multiple Targets', () => {
-    it('should create entries for all targets when shape has multiple targetClass', async () => {
-      const content = `
-        @prefix sh: <http://www.w3.org/ns/shacl#> .
-        @prefix ex: <http://example.org/> .
-        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-        ex:PersonOrEmployeeShape
-            a sh:NodeShape ;
-            sh:targetClass ex:Person ;
-            sh:targetClass ex:Employee ;
-            sh:property [
-                sh:path ex:name ;
-                sh:datatype xsd:string ;
-            ] .
-
-        ex:AnotherPersonShape
-            a sh:NodeShape ;
-            sh:targetClass ex:Person ;
-            sh:property [
-                sh:path ex:age ;
-                sh:datatype xsd:integer ;
-            ] .
-      `;
-      const ir = await getIr(content);
-      const schema = new IrSchemaConverter(ir).convert();
-
-      expect(schema).toStrictEqual({
-        $defs: {
-          Person_1: {
-            title: 'Person_1',
-            type: 'object',
-            properties: {
-              name: {
-                type: 'string',
-              },
-            },
-            additionalProperties: true,
-          },
-          Employee: {
-            title: 'Employee',
-            type: 'object',
-            properties: {
-              name: {
-                type: 'string',
-              },
-            },
-            additionalProperties: true,
-          },
-          Person_2: {
-            title: 'Person_2',
-            type: 'object',
-            properties: {
-              age: {
-                type: 'integer',
-              },
-            },
-            additionalProperties: true,
-          },
-        },
-        $id: 'http://example.org/PersonOrEmployeeShape',
-        $ref: '#/$defs/Person_1',
-        $schema: 'https://json-schema.org/draft/2020-12/schema',
-        'x-shacl-prefixes': {
-          sh: 'http://www.w3.org/ns/shacl#',
-          ex: 'http://example.org/',
-          xsd: 'http://www.w3.org/2001/XMLSchema#',
-        },
-      });
-    });
-
-    it('should create entries for all targets without numbering when no duplicates', async () => {
+  describe('Multi-Target Shapes', () => {
+    it('should create entries for all targets without merging when no duplicates', async () => {
       const content = `
         @prefix sh: <http://www.w3.org/ns/shacl#> .
         @prefix ex: <http://example.org/> .
@@ -715,74 +811,12 @@ describe('IR Schema Converter - Targets', () => {
     });
   });
 
-  describe('Other Target Types', () => {
-    it('should number duplicate targetNode declarations', async () => {
+  describe('Advanced Target Types', () => {
+    it('should merge duplicate targetSubjectsOf declarations', async () => {
       const content = `
         @prefix sh: <http://www.w3.org/ns/shacl#> .
         @prefix ex: <http://example.org/> .
         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-        ex:JohnShape1
-            a sh:NodeShape ;
-            sh:targetNode ex:john ;
-            sh:property [
-                sh:path ex:name ;
-                sh:datatype xsd:string ;
-            ] .
-
-        ex:JohnShape2
-            a sh:NodeShape ;
-            sh:targetNode ex:john ;
-            sh:property [
-                sh:path ex:age ;
-                sh:datatype xsd:integer ;
-            ] .
-      `;
-      const ir = await getIr(content);
-      const schema = new IrSchemaConverter(ir).convert();
-
-      expect(schema).toStrictEqual({
-        $defs: {
-          john_1: {
-            additionalProperties: true,
-            properties: {
-              name: {
-                type: 'string',
-              },
-            },
-            title: 'john_1',
-            type: 'object',
-            'x-shacl-targetNodes': ['http://example.org/john'],
-          },
-          john_2: {
-            additionalProperties: true,
-            properties: {
-              age: {
-                type: 'integer',
-              },
-            },
-            title: 'john_2',
-            type: 'object',
-            'x-shacl-targetNodes': ['http://example.org/john'],
-          },
-        },
-        $id: 'http://example.org/JohnShape1',
-        $ref: '#/$defs/john_1',
-        $schema: 'https://json-schema.org/draft/2020-12/schema',
-        'x-shacl-prefixes': {
-          ex: 'http://example.org/',
-          sh: 'http://www.w3.org/ns/shacl#',
-          xsd: 'http://www.w3.org/2001/XMLSchema#',
-        },
-      });
-    });
-
-    it('should number duplicate targetSubjectsOf declarations', async () => {
-      const content = `
-        @prefix sh: <http://www.w3.org/ns/shacl#> .
-        @prefix ex: <http://example.org/> .
-        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
         ex:alice ex:knows ex:bob .
         ex:charlie ex:knows ex:dave .
@@ -806,78 +840,25 @@ describe('IR Schema Converter - Targets', () => {
       const ir = await getIr(content);
       const schema = new IrSchemaConverter(ir).convert();
 
-      expect(schema).toStrictEqual({
-        $defs: {
-          alice: {
-            additionalProperties: true,
-            title: 'alice',
-            type: 'object',
-            'x-shacl-knows': 'http://example.org/bob',
-          },
-          alice_1: {
-            additionalProperties: true,
-            properties: {
-              name: {
-                type: 'string',
-              },
-            },
-            title: 'alice_1',
-            type: 'object',
-            'x-shacl-targetSubjectsOf': 'http://example.org/knows',
-          },
-          alice_2: {
-            additionalProperties: true,
-            properties: {
-              age: {
-                type: 'integer',
-              },
-            },
-            title: 'alice_2',
-            type: 'object',
-            'x-shacl-targetSubjectsOf': 'http://example.org/knows',
-          },
-          charlie: {
-            additionalProperties: true,
-            title: 'charlie',
-            type: 'object',
-            'x-shacl-knows': 'http://example.org/dave',
-          },
-          charlie_1: {
-            additionalProperties: true,
-            properties: {
-              name: {
-                type: 'string',
-              },
-            },
-            title: 'charlie_1',
-            type: 'object',
-            'x-shacl-targetSubjectsOf': 'http://example.org/knows',
-          },
-          charlie_2: {
-            additionalProperties: true,
-            properties: {
-              age: {
-                type: 'integer',
-              },
-            },
-            title: 'charlie_2',
-            type: 'object',
-            'x-shacl-targetSubjectsOf': 'http://example.org/knows',
-          },
+      // Should have merged schemas for alice and charlie (both subjects of ex:knows)
+      expect(schema.$defs?.alice).toMatchObject({
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'integer' },
         },
-        $id: 'http://example.org/alice',
-        $ref: '#/$defs/alice',
-        $schema: 'https://json-schema.org/draft/2020-12/schema',
-        'x-shacl-prefixes': {
-          ex: 'http://example.org/',
-          rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-          sh: 'http://www.w3.org/ns/shacl#',
-          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        'x-shacl-targetSubjectsOf': 'http://example.org/knows',
+      });
+
+      expect(schema.$defs?.charlie).toMatchObject({
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'integer' },
         },
+        'x-shacl-targetSubjectsOf': 'http://example.org/knows',
       });
     });
 
-    it('should number duplicate targetObjectsOf declarations', async () => {
+    it('should merge duplicate targetObjectsOf declarations', async () => {
       const content = `
         @prefix sh: <http://www.w3.org/ns/shacl#> .
         @prefix ex: <http://example.org/> .
@@ -905,57 +886,19 @@ describe('IR Schema Converter - Targets', () => {
       const ir = await getIr(content);
       const schema = new IrSchemaConverter(ir).convert();
 
-      expect(schema).toStrictEqual({
-        $defs: {
-          alice: {
-            additionalProperties: true,
-            title: 'alice',
-            type: 'object',
-            'x-shacl-knows': 'http://example.org/bob',
-          },
-          bob_1: {
-            additionalProperties: true,
-            properties: {
-              name: {
-                type: 'string',
-              },
-            },
-            title: 'bob_1',
-            type: 'object',
-            'x-shacl-targetObjectsOf': 'http://example.org/knows',
-          },
-          bob_2: {
-            additionalProperties: true,
-            properties: {
-              age: {
-                type: 'integer',
-              },
-            },
-            title: 'bob_2',
-            type: 'object',
-            'x-shacl-targetObjectsOf': 'http://example.org/knows',
-          },
-          charlie: {
-            additionalProperties: true,
-            title: 'charlie',
-            type: 'object',
-            'x-shacl-knows': 'http://example.org/bob',
-          },
+      // Should have merged schema for bob (object of ex:knows)
+      expect(schema.$defs?.bob).toMatchObject({
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'integer' },
         },
-        $id: 'http://example.org/alice',
-        $ref: '#/$defs/alice',
-        $schema: 'https://json-schema.org/draft/2020-12/schema',
-        'x-shacl-prefixes': {
-          ex: 'http://example.org/',
-          sh: 'http://www.w3.org/ns/shacl#',
-          xsd: 'http://www.w3.org/2001/XMLSchema#',
-        },
+        'x-shacl-targetObjectsOf': 'http://example.org/knows',
       });
     });
   });
 
   describe('Complex Scenarios', () => {
-    it('should handle mix of target types with duplicates', async () => {
+    it('should handle mix of target types with merging', async () => {
       const content = `
         @prefix sh: <http://www.w3.org/ns/shacl#> .
         @prefix ex: <http://example.org/> .
@@ -990,44 +933,387 @@ describe('IR Schema Converter - Targets', () => {
 
       expect(schema).toStrictEqual({
         $defs: {
-          Person_1: {
+          Person: {
+            title: 'Person',
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              age: { type: 'integer' },
+              id: { type: 'string' },
+            },
+            additionalProperties: true,
+            'x-shacl-targetNodes': ['http://example.org/Person'],
+          },
+        },
+        $id: 'http://example.org/PersonShape1',
+        $ref: '#/$defs/Person',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+  });
+
+  describe('Property Conflicts', () => {
+    it('should handle same property with different constraints - last wins', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:PersonShape1
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [
+                sh:path ex:name ;
+                sh:datatype xsd:string ;
+                sh:minLength 5 ;
+            ] .
+
+        ex:PersonShape2
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [
+                sh:path ex:name ;
+                sh:datatype xsd:string ;
+                sh:minLength 10 ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          Person: {
+            title: 'Person',
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+                minLength: 10,
+              },
+            },
+            required: ['name'],
+            additionalProperties: true,
+          },
+        },
+        $id: 'http://example.org/PersonShape1',
+        $ref: '#/$defs/Person',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+
+    it('should handle same property with different datatypes - last wins', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:PersonShape1
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [
+                sh:path ex:value ;
+                sh:datatype xsd:string ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] .
+
+        ex:PersonShape2
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [
+                sh:path ex:value ;
+                sh:datatype xsd:integer ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          Person: {
+            title: 'Person',
+            type: 'object',
+            properties: {
+              value: {
+                type: 'integer',
+              },
+            },
+            additionalProperties: true,
+            required: ['value'],
+          },
+        },
+        $id: 'http://example.org/PersonShape1',
+        $ref: '#/$defs/Person',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+
+    it('should handle same property with different cardinality - last wins', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:PersonShape1
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [
+                sh:path ex:email ;
+                sh:datatype xsd:string ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ] .
+
+        ex:PersonShape2
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [
+                sh:path ex:email ;
+                sh:datatype xsd:string ;
+                sh:minCount 2 ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          Person: {
+            title: 'Person',
+            type: 'object',
+            properties: {
+              email: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+                minItems: 2,
+              },
+            },
+            additionalProperties: true,
+            required: ['email'],
+          },
+        },
+        $id: 'http://example.org/PersonShape1',
+        $ref: '#/$defs/Person',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle empty shape merged with shape having properties', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:PersonShape1
+            a sh:NodeShape ;
+            sh:targetClass ex:Person .
+
+        ex:PersonShape2
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [
+                sh:path ex:name ;
+                sh:datatype xsd:string ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          Person: {
+            title: 'Person',
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+              },
+            },
+            additionalProperties: true,
+          },
+        },
+        $id: 'http://example.org/PersonShape1',
+        $ref: '#/$defs/Person',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+
+    it('should handle both shapes being closed with different properties', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:PersonShape1
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:closed true ;
+            sh:property [
+                sh:path ex:name ;
+                sh:datatype xsd:string ;
+            ] .
+
+        ex:PersonShape2
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:closed true ;
+            sh:property [
+                sh:path ex:age ;
+                sh:datatype xsd:integer ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          Person: {
+            title: 'Person',
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+              },
+              age: {
+                type: 'integer',
+              },
+            },
+            additionalProperties: false,
+          },
+        },
+        $id: 'http://example.org/PersonShape1',
+        $ref: '#/$defs/Person',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+
+    it('should handle single shape with no target declarations', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:PersonShape
+            a sh:NodeShape ;
+            sh:property [
+                sh:path ex:name ;
+                sh:datatype xsd:string ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          Person: {
             additionalProperties: true,
             properties: {
               name: {
                 type: 'string',
               },
             },
-            title: 'Person_1',
+            title: 'Person',
             type: 'object',
-          },
-          Person_2: {
-            additionalProperties: true,
-            properties: {
-              age: {
-                type: 'integer',
-              },
-            },
-            title: 'Person_2',
-            type: 'object',
-          },
-          Person_3: {
-            additionalProperties: true,
-            properties: {
-              id: {
-                type: 'string',
-              },
-            },
-            title: 'Person_3',
-            type: 'object',
-            'x-shacl-targetNodes': ['http://example.org/Person'],
           },
         },
-        $id: 'http://example.org/PersonShape1',
-        $ref: '#/$defs/Person_1',
+        $id: 'http://example.org/PersonShape',
+        $ref: '#/$defs/Person',
         $schema: 'https://json-schema.org/draft/2020-12/schema',
         'x-shacl-prefixes': {
           ex: 'http://example.org/',
           sh: 'http://www.w3.org/ns/shacl#',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+  });
+
+  describe('Metadata Preservation', () => {
+    it('should preserve shape metadata when merging', async () => {
+      const content = `
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:PersonShape1
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:message "Person validation failed" ;
+            sh:property [
+                sh:path ex:name ;
+                sh:datatype xsd:string ;
+            ] .
+
+        ex:PersonShape2
+            a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [
+                sh:path ex:age ;
+                sh:datatype xsd:integer ;
+            ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $defs: {
+          Person: {
+            title: 'Person',
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+              },
+              age: {
+                type: 'integer',
+              },
+            },
+            additionalProperties: true,
+            'x-shacl-message': 'Person validation failed',
+          },
+        },
+        $id: 'http://example.org/PersonShape1',
+        $ref: '#/$defs/Person',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
           xsd: 'http://www.w3.org/2001/XMLSchema#',
         },
       });

--- a/src/json-schema/ir-schema-converter.ts
+++ b/src/json-schema/ir-schema-converter.ts
@@ -26,26 +26,49 @@ export class IrSchemaConverter {
   convert(): JsonSchemaObjectType {
     const builder = new JsonSchemaObjectBuilder();
     if (this.shapeDefinitions.length == 0) return builder.build();
-    this.shapeDefinitions
-      .map((shapeDefinition) => {
-        return { shape: shapeDefinition, schema: this.processBottomUp(shapeDefinition) };
-      })
-      .forEach((element) => {
-        const { shape, schema } = element;
-        shape.targets.forEach((target) => {
-          const schemaForTarget = { ...schema, title: target };
-          builder.$defs({
-            ...(builder.getKey('$defs') as Record<string, JsonSchemaType>),
-            [target]: schemaForTarget,
-          });
-        });
-      });
+
+    const targetToShapesMap = this.groupShapesByTarget();
+
+    const mergedSchemas = new Map<string, JsonSchemaObjectType>();
+
+    targetToShapesMap.forEach((shapes, target) => {
+      const schemasForTarget = shapes.map((shape) => this.processBottomUp(shape));
+      const mergedSchema = this.mergeSchemas(schemasForTarget, target);
+      mergedSchemas.set(target, mergedSchema);
+    });
+
+    const defs: Record<string, JsonSchemaType> = {};
+    mergedSchemas.forEach((schema, target) => {
+      defs[target] = schema;
+    });
+
     return builder
       .$id(this.shapeDefinitions[0].nodeKey)
       .$schema(JSON_SCHEMA_DRAFT)
+      .$defs(defs)
       .$ref(`#/$defs/${this.shapeDefinitions[0].targets[0]}`)
       .customProperty('x-shacl-prefixes', this.addPrefixes())
       .build();
+  }
+
+  private groupShapesByTarget(): Map<string, ShapeDefinition[]> {
+    const targetToShapesMap = new Map<string, ShapeDefinition[]>();
+    this.shapeDefinitions.forEach((shape) => {
+      shape.targets.forEach((target) => {
+        const existing = targetToShapesMap.get(target) ?? [];
+        existing.push(shape);
+        targetToShapesMap.set(target, existing);
+      });
+    });
+    return targetToShapesMap;
+  }
+
+  private mergeSchemas(schemas: JsonSchemaObjectType[], target: string): JsonSchemaObjectType {
+    if (schemas.length === 0) return {};
+    if (schemas.length === 1) return { ...schemas[0], title: target };
+    const baseBuilder = new JsonSchemaObjectBuilder().title(target);
+    schemas.forEach((schema) => baseBuilder.deepMerge(schema));
+    return baseBuilder.build();
   }
 
   private isLogicalConstraintFragment(parentShape: ShapeDefinition, childNodeKey: string): boolean {

--- a/src/json-schema/meta/json-schema-object-builder.ts
+++ b/src/json-schema/meta/json-schema-object-builder.ts
@@ -427,4 +427,40 @@ export class JsonSchemaObjectBuilder {
     });
     return this;
   }
+
+  /**
+   * Deep merges another schema into this one.
+   * Used for combining multiple SHACL shapes targeting the same class.
+   * - Properties are merged (combined from both schemas)
+   * - Required arrays are merged (union of both)
+   * - additionalProperties: false takes precedence (closed shapes)
+   * - Other properties from source are added if not present
+   */
+  deepMerge(source: JsonSchemaObjectType): this {
+    // Merge properties
+    if (source.properties) {
+      this.schema.properties = {
+        ...this.schema.properties,
+        ...source.properties,
+      };
+    }
+
+    // Merge required fields (union)
+    if (source.required)
+      this.schema.required = [...new Set([...(this.schema.required ?? []), ...source.required])];
+
+    // Handle additionalProperties - if any shape is closed (false), result is closed
+    if (source.additionalProperties === false) this.schema.additionalProperties = false;
+    else this.schema.additionalProperties ??= source.additionalProperties;
+
+    // Merge other keys that don't conflict
+    Object.keys(source)
+      .filter((key) => !['properties', 'additionalProperties', 'required', 'title'].includes(key))
+      .filter((key) => this.schema[key] === undefined)
+      .forEach((key) => {
+        this.schema[key] = source[key];
+      });
+
+    return this;
+  }
 }


### PR DESCRIPTION
## Description

- Modify code to merge schemas that have the same targets
- Previously, a numbering strategy was adopted

Fixes #50 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

- Remove numbering logic from target resolution
- Add code to deepMerge JSON Schema Builders
- Add code in schema conversion to group targets and merge schemas

## Testing

Please describe the tests you ran to verify your changes:

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality
- [ ] Tested manually with sample SHACL files

## Checklist

- [x] My code follows the project's code style
- [x] I have run `npm run fix:lint-format`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings