### PR TITLE
fix(json-schema): add support for merging allOf blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
+        "@types/json-schema-merge-allof": "^0.6.5",
         "clipboardy": "^5.0.2",
         "commander": "^14.0.2",
+        "json-schema-merge-allof": "^0.8.1",
         "jsonld": "^9.0.0",
         "n3": "^2.0.1",
         "pino": "^10.2.0",
@@ -2343,8 +2345,16 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/json-schema-merge-allof": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@types/json-schema-merge-allof/-/json-schema-merge-allof-0.6.5.tgz",
+      "integrity": "sha512-5mS11ZUTyFNUVEMpK3uKoPb6BWL/nLgW/ln2VOiI8OOxKEYC4Gl9O3WjS5P49yqVTfkcbCAPKw3T1O4erUah5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "*"
+      }
     },
     "node_modules/@types/jsonld": {
       "version": "1.5.15",
@@ -3943,6 +3953,27 @@
       "dependencies": {
         "array-ify": "^1.0.0",
         "dot-prop": "^5.1.0"
+      }
+    },
+    "node_modules/compute-gcd": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
+      "integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
+      "dependencies": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
+    "node_modules/compute-lcm": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
+      "integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
+      "dependencies": {
+        "compute-gcd": "^1.2.1",
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
       }
     },
     "node_modules/concat-map": {
@@ -6478,6 +6509,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-compare": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
+      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/json-schema-merge-allof": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.8.1.tgz",
+      "integrity": "sha512-CTUKmIlPJbsWfzRRnOXz+0MjIqvnleIXwFTzz+t9T86HnYX/Rozria6ZVGLktAU9e+NygNljveP+yxqtQp/Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "compute-lcm": "^1.1.2",
+        "json-schema-compare": "^0.2.2",
+        "lodash": "^4.17.20"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -6664,7 +6718,6 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -11999,6 +12052,39 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "node_modules/validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg==",
+      "license": "MIT"
+    },
+    "node_modules/validate.io-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+      "integrity": "sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ=="
+    },
+    "node_modules/validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha512-22izsYSLojN/P6bppBqhgUDjCkr5RY2jd+N2a3DCAUey8ydvrZ/OkGvFPR7qfOpwR2LC5p4Ngzxz36g5Vgr/hQ==",
+      "dependencies": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "node_modules/validate.io-integer-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
+      "integrity": "sha512-mTrMk/1ytQHtCY0oNO3dztafHYyGU88KL+jRxWuzfOmQb+4qqnWmI+gykvGp8usKZOM0H7keJHEbRaFiYA0VrA==",
+      "dependencies": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-integer": "^1.0.4"
+      }
+    },
+    "node_modules/validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg=="
     },
     "node_modules/walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -63,8 +63,10 @@
     "typescript-eslint": "^8.53.0"
   },
   "dependencies": {
+    "@types/json-schema-merge-allof": "^0.6.5",
     "clipboardy": "^5.0.2",
     "commander": "^14.0.2",
+    "json-schema-merge-allof": "^0.8.1",
     "jsonld": "^9.0.0",
     "n3": "^2.0.1",
     "pino": "^10.2.0",

--- a/src/json-schema/converters/constraints/constraint-converter.test.ts
+++ b/src/json-schema/converters/constraints/constraint-converter.test.ts
@@ -502,7 +502,7 @@ describe('ConstraintConverter', () => {
 
         expect(result.anyOf).toBeDefined();
         expect(result.anyOf).toHaveLength(1);
-        expect(result.anyOf?.[0]).toEqual({ type: 'string' });
+        expect(result.anyOf?.[0]).toEqual({ $ref: '#/$defs/Referenced' });
       });
 
       it('should not apply anyOf when null', () => {
@@ -533,7 +533,7 @@ describe('ConstraintConverter', () => {
 
         expect(result.allOf).toBeDefined();
         expect(result.allOf).toHaveLength(1);
-        expect(result.allOf?.[0]).toEqual({ type: 'string' });
+        expect(result.allOf?.[0]).toEqual({ $ref: '#/$defs/Referenced' });
       });
 
       it('should not apply allOf when null', () => {
@@ -555,7 +555,7 @@ describe('ConstraintConverter', () => {
 
         expect(result.oneOf).toBeDefined();
         expect(result.oneOf).toHaveLength(1);
-        expect(result.oneOf?.[0]).toEqual({ type: 'string' });
+        expect(result.oneOf?.[0]).toEqual({ $ref: '#/$defs/Referenced' });
       });
 
       it('should not apply oneOf when null', () => {
@@ -576,7 +576,7 @@ describe('ConstraintConverter', () => {
         const result = converter.convert();
 
         expect(result.not).toBeDefined();
-        expect(result.not).toEqual({ type: 'string' });
+        expect(result.not).toEqual({ $ref: '#/$defs/Referenced' });
       });
 
       it('should not apply not when null', () => {

--- a/src/json-schema/converters/constraints/constraint-converter.ts
+++ b/src/json-schema/converters/constraints/constraint-converter.ts
@@ -364,8 +364,14 @@ export class ConstraintConverter {
                   .map((shape) => {
                     if (shape) return this.processed.get(shape);
                   })
-                  .map((ele) => ele?.builder.build())
-                  .filter((schema) => schema != null) ?? [];
+                  .filter((ele) => ele != null)
+                  .map((ele) =>
+                    ele.shape.nodeKey.includes('n3')
+                      ? ele.builder.build()
+                      : new JsonSchemaObjectBuilder()
+                          .$ref(`#/$defs/${extractStrippedName(ele.shape.nodeKey)}`)
+                          .build()
+                  ) ?? [];
               if (orSchemas.length > 0) builder.anyOf(orSchemas);
             })
             .execute();
@@ -387,8 +393,14 @@ export class ConstraintConverter {
                   .map((shape) => {
                     if (shape) return this.processed.get(shape);
                   })
-                  .map((ele) => ele?.builder.build())
-                  .filter((schema) => schema != null) ?? [];
+                  .filter((ele) => ele != null)
+                  .map((ele) =>
+                    ele.shape.nodeKey.includes('n3')
+                      ? ele.builder.build()
+                      : new JsonSchemaObjectBuilder()
+                          .$ref(`#/$defs/${extractStrippedName(ele.shape.nodeKey)}`)
+                          .build()
+                  ) ?? [];
               if (andSchemas.length > 0) builder.allOf(andSchemas);
             })
             .execute();
@@ -410,8 +422,14 @@ export class ConstraintConverter {
                   .map((shape) => {
                     if (shape) return this.processed.get(shape);
                   })
-                  .map((ele) => ele?.builder.build())
-                  .filter((schema) => schema != null) ?? [];
+                  .filter((ele) => ele != null)
+                  .map((ele) =>
+                    ele.shape.nodeKey.includes('n3')
+                      ? ele.builder.build()
+                      : new JsonSchemaObjectBuilder()
+                          .$ref(`#/$defs/${extractStrippedName(ele.shape.nodeKey)}`)
+                          .build()
+                  ) ?? [];
               if (xoneSchemas.length > 0) builder.oneOf(xoneSchemas);
             })
             .execute();
@@ -430,8 +448,14 @@ export class ConstraintConverter {
                 .map((shape) => {
                   if (shape) return this.processed.get(shape);
                 })
-                .map((ele) => ele?.builder.build())
-                .filter((schema) => schema != null)
+                .filter((ele) => ele != null)
+                .map((ele) =>
+                  ele.shape.nodeKey.includes('n3')
+                    ? ele.builder.build()
+                    : new JsonSchemaObjectBuilder()
+                        .$ref(`#/$defs/${extractStrippedName(ele.shape.nodeKey)}`)
+                        .build()
+                )
                 .pop();
               if (notSchema == null) return;
               builder.not(notSchema);

--- a/src/json-schema/ir-schema-converter.merge-allof.test.ts
+++ b/src/json-schema/ir-schema-converter.merge-allof.test.ts
@@ -1,0 +1,380 @@
+import {
+  IntermediateRepresentation,
+  IntermediateRepresentationBuilder,
+} from '../ir/intermediate-representation-builder';
+import { ShaclParser } from '../shacl/shacl-parser';
+import { IrSchemaConverter } from './ir-schema-converter';
+
+async function getIr(content: string): Promise<IntermediateRepresentation> {
+  const shaclDocument = await new ShaclParser().withContent(content).parse();
+  return new IntermediateRepresentationBuilder(shaclDocument).build();
+}
+
+describe('IR Schema Converter - Merge allOf', () => {
+  describe('Multiple $ref preservation', () => {
+    it('real world usecase', async () => {
+      const content = `
+       @prefix sh:  <http://www.w3.org/ns/shacl#> .
+@prefix ex:  <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+### Base shape: must have a name
+ex:NamedShape
+    a sh:NodeShape ;
+    sh:property [
+        sh:path ex:name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] .
+
+### Base shape: must have an email
+ex:EmailRequiredShape
+    a sh:NodeShape ;
+    sh:property [
+        sh:path ex:email ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[^@]+@[^@]+\\\\.[^@]+$" ;
+    ] .
+
+### Base shape: must have an age in a range
+ex:AdultShape
+    a sh:NodeShape ;
+    sh:property [
+        sh:path ex:age ;
+        sh:datatype xsd:integer ;
+        sh:minCount 1 ;
+        sh:minInclusive 18 ;
+        sh:maxInclusive 120 ;
+    ] .
+
+### Final shape: combines them all (ALL must hold)
+ex:PersonShape
+    a sh:NodeShape ;
+    sh:targetClass ex:Person ;
+    sh:and (
+        ex:NamedShape
+        ex:EmailRequiredShape
+        ex:AdultShape
+    ) .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+      expect(schema).toStrictEqual({
+        $defs: {
+          Adult: {
+            additionalProperties: true,
+            properties: {
+              age: {
+                items: {
+                  type: 'integer',
+                },
+                maximum: 120,
+                minItems: 1,
+                minimum: 18,
+                type: 'array',
+              },
+            },
+            required: ['age'],
+            title: 'Adult',
+            type: 'object',
+          },
+          EmailRequired: {
+            additionalProperties: true,
+            properties: {
+              email: {
+                pattern: '^[^@]+@[^@]+\\.[^@]+$',
+                type: 'string',
+              },
+            },
+            required: ['email'],
+            title: 'EmailRequired',
+            type: 'object',
+          },
+          Named: {
+            additionalProperties: true,
+            properties: {
+              name: {
+                minLength: 1,
+                type: 'string',
+              },
+            },
+            required: ['name'],
+            title: 'Named',
+            type: 'object',
+          },
+          Person: {
+            additionalProperties: true,
+            allOf: [
+              {
+                $ref: '#/$defs/Named',
+              },
+              {
+                $ref: '#/$defs/EmailRequired',
+              },
+              {
+                $ref: '#/$defs/Adult',
+              },
+            ],
+            title: 'Person',
+            type: 'object',
+          },
+        },
+        $id: 'http://example.org/NamedShape',
+        $ref: '#/$defs/Named',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        'x-shacl-prefixes': {
+          ex: 'http://example.org/',
+          sh: 'http://www.w3.org/ns/shacl#',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+  });
+
+  describe('allOf with multiple $ref entries', () => {
+    it('should preserve allOf with multiple $ref entries', async () => {
+      const content = `
+@prefix sh:  <http://www.w3.org/ns/shacl#> .
+@prefix ex:  <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:NamedShape
+    a sh:NodeShape ;
+    sh:property [
+        sh:path ex:name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+    ] .
+
+ex:EmailShape
+    a sh:NodeShape ;
+    sh:property [
+        sh:path ex:email ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+    ] .
+
+ex:PersonShape
+    a sh:NodeShape ;
+    sh:targetClass ex:Person ;
+    sh:and (
+        ex:NamedShape
+        ex:EmailShape
+    ) .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        $id: 'http://example.org/NamedShape',
+        $ref: '#/$defs/Named',
+        $defs: {
+          Person: {
+            type: 'object',
+            title: 'Person',
+            additionalProperties: true,
+            allOf: [{ $ref: '#/$defs/Named' }, { $ref: '#/$defs/Email' }],
+          },
+          Named: {
+            type: 'object',
+            title: 'Named',
+            additionalProperties: true,
+            properties: {
+              name: {
+                type: 'array',
+                items: { type: 'string' },
+                minItems: 1,
+              },
+            },
+            required: ['name'],
+          },
+          Email: {
+            type: 'object',
+            title: 'Email',
+            additionalProperties: true,
+            properties: {
+              email: {
+                type: 'array',
+                items: { type: 'string' },
+                minItems: 1,
+              },
+            },
+            required: ['email'],
+          },
+        },
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+  });
+
+  describe('Nested anyOf flattening', () => {
+    it('should not wrap anyOf inside not with extra anyOf', async () => {
+      const content = `
+@prefix sh:  <http://www.w3.org/ns/shacl#> .
+@prefix ex:  <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:SafeMimeTypeShape
+    a sh:NodeShape ;
+    sh:targetClass ex:MimeType ;
+    sh:property [
+        sh:path ex:mimeType ;
+        sh:datatype xsd:string ;
+        sh:not [
+            sh:or (
+                [ sh:pattern "^application/x-.*" ]
+                [ sh:pattern "^application/.*executable.*" ]
+            )
+        ]
+    ] .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toStrictEqual({
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        $id: 'http://example.org/SafeMimeTypeShape',
+        $ref: '#/$defs/MimeType',
+        $defs: {
+          MimeType: {
+            type: 'object',
+            title: 'MimeType',
+            additionalProperties: true,
+            properties: {
+              mimeType: {
+                type: 'string',
+                not: {
+                  anyOf: [
+                    { pattern: '^application/x-.*' },
+                    { pattern: '^application/.*executable.*' },
+                  ],
+                },
+              },
+            },
+          },
+        },
+        'x-shacl-prefixes': {
+          sh: 'http://www.w3.org/ns/shacl#',
+          ex: 'http://example.org/',
+          xsd: 'http://www.w3.org/2001/XMLSchema#',
+        },
+      });
+    });
+  });
+
+  describe('anyOf with multiple $ref entries', () => {
+    it('should preserve anyOf with multiple $ref entries for sh:or', async () => {
+      const content = `
+@prefix sh:  <http://www.w3.org/ns/shacl#> .
+@prefix ex:  <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:StringShape
+    a sh:NodeShape ;
+    sh:property [
+        sh:path ex:value ;
+        sh:datatype xsd:string ;
+    ] .
+
+ex:IntegerShape
+    a sh:NodeShape ;
+    sh:property [
+        sh:path ex:value ;
+        sh:datatype xsd:integer ;
+    ] .
+
+ex:FlexibleShape
+    a sh:NodeShape ;
+    sh:targetClass ex:Flexible ;
+    sh:or (
+        ex:StringShape
+        ex:IntegerShape
+    ) .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      const flexibleDef = schema.$defs?.Flexible as { anyOf?: unknown[] };
+      expect(flexibleDef.anyOf).toStrictEqual([
+        { $ref: '#/$defs/String' },
+        { $ref: '#/$defs/Integer' },
+      ]);
+    });
+  });
+
+  describe('oneOf with multiple $ref entries', () => {
+    it('should preserve oneOf with multiple $ref entries for sh:xone', async () => {
+      const content = `
+@prefix sh:  <http://www.w3.org/ns/shacl#> .
+@prefix ex:  <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:OptionAShape
+    a sh:NodeShape ;
+    sh:property [
+        sh:path ex:optionA ;
+        sh:datatype xsd:string ;
+    ] .
+
+ex:OptionBShape
+    a sh:NodeShape ;
+    sh:property [
+        sh:path ex:optionB ;
+        sh:datatype xsd:string ;
+    ] .
+
+ex:ExclusiveShape
+    a sh:NodeShape ;
+    sh:targetClass ex:Exclusive ;
+    sh:xone (
+        ex:OptionAShape
+        ex:OptionBShape
+    ) .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      const exclusiveDef = schema.$defs?.Exclusive as { oneOf?: unknown[] };
+      expect(exclusiveDef.oneOf).toStrictEqual([
+        { $ref: '#/$defs/OptionA' },
+        { $ref: '#/$defs/OptionB' },
+      ]);
+    });
+  });
+
+  describe('not with named shape $ref', () => {
+    it('should use $ref for sh:not with named shape', async () => {
+      const content = `
+@prefix sh:  <http://www.w3.org/ns/shacl#> .
+@prefix ex:  <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:RestrictedShape
+    a sh:NodeShape ;
+    sh:property [
+        sh:path ex:restricted ;
+        sh:hasValue "forbidden" ;
+    ] .
+
+ex:AllowedShape
+    a sh:NodeShape ;
+    sh:targetClass ex:Allowed ;
+    sh:not ex:RestrictedShape .
+      `;
+      const ir = await getIr(content);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      const allowedDef = schema.$defs?.Allowed as { not?: unknown };
+      expect(allowedDef.not).toStrictEqual({ $ref: '#/$defs/Restricted' });
+    });
+  });
+});

--- a/src/json-schema/ir-schema-converter.ts
+++ b/src/json-schema/ir-schema-converter.ts
@@ -13,6 +13,7 @@ import { ConstraintConverter } from './converters/constraints/constraint-convert
 import { Condition } from '../condition/condition';
 import { ShaclDocument } from '../shacl/shacl-document';
 import { ConversionOptions } from './conversion-options';
+import mergeAllOf from 'json-schema-merge-allof';
 
 export class IrSchemaConverter {
   private processed = new Map<ShapeDefinition, StackElement>();
@@ -49,7 +50,7 @@ export class IrSchemaConverter {
     });
 
     builder
-      .$id(this.shapeDefinitions[0].nodeKey)
+      .$id(this.shapeDefinitions[0].nodeKey) // TODO: Nee better root resolution
       .$schema(JSON_SCHEMA_DRAFT)
       .$defs(defs)
       .$ref(`#/$defs/${this.shapeDefinitions[0].targets[0]}`);
@@ -58,7 +59,12 @@ export class IrSchemaConverter {
       builder.customProperty('x-shacl-prefixes', this.addPrefixes());
     }
 
-    return builder.build();
+    return mergeAllOf(
+      builder.build() as Parameters<typeof mergeAllOf>[0],
+      {
+        deep: true,
+      } as Parameters<typeof mergeAllOf>[1]
+    ) as JsonSchemaObjectType;
   }
 
   private groupShapesByTarget(): Map<string, ShapeDefinition[]> {


### PR DESCRIPTION
## Description

- Add support for merging allOf blocks in the generated JSON Schema

Fixes #75 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

- Add code to merge allOf blocks of the final schema generated

## Testing

Please describe the tests you ran to verify your changes:

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality
- [ ] Tested manually with sample SHACL files

## Checklist

- [ ] My code follows the project's code style
- [x] I have run `npm run fix:lint-format`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings