### PR TITLE
fix(conversion): fix remnant blank nodes in references

### DIFF
--- a/src/ir/target-resolver.ts
+++ b/src/ir/target-resolver.ts
@@ -1,5 +1,6 @@
-import { Quad, Quad_Subject, Term, Util } from 'n3';
+import { Quad, Quad_Subject, Term } from 'n3';
 import {
+  SHACL_CLASS,
   SHACL_PATH,
   SHACL_TARGET_CLASS,
   SHACL_TARGET_NODE,
@@ -8,7 +9,6 @@ import {
 } from '../shacl/shacl-terms';
 import { extractStrippedName } from '../util/helpers';
 import { ShaclDocument } from '../shacl/shacl-document';
-import isBlankNode = Util.isBlankNode;
 
 const TARGET_DEFINITIONS = [
   SHACL_TARGET_CLASS,
@@ -16,6 +16,7 @@ const TARGET_DEFINITIONS = [
   SHACL_TARGET_SUBJECTS_OF,
   SHACL_TARGET_OBJECTS_OF,
   SHACL_PATH,
+  SHACL_CLASS,
 ];
 
 export function getTarget(targets: Map<Term, string[]>, search: string) {
@@ -55,13 +56,6 @@ export class TargetResolver {
     targetDeclarations: { predicate: string; object: string }[],
     subject: Quad_Subject
   ): string[] {
-    if (isBlankNode(subject)) {
-      return targetDeclarations
-        .filter((target) => target.predicate === SHACL_PATH)
-        .map((target) => target.object)
-        .map(extractStrippedName);
-    }
-
     const targetClasses = targetDeclarations
       .filter((target) => target.predicate === SHACL_TARGET_CLASS)
       .map((target) => target.object)
@@ -92,12 +86,36 @@ export class TargetResolver {
       .map((quad) => quad.object.value)
       .map(extractStrippedName);
 
-    const noTargets = [targetSubjects, targetObjects, targetClasses, targetNodes].every(
-      (arr) => arr.length === 0
-    );
+    const targetPaths = targetDeclarations
+      .filter((target) => target.predicate === SHACL_PATH)
+      .map((target) => target.object)
+      .map(extractStrippedName);
+
+    const classes = targetDeclarations
+      .filter((target) => target.predicate === SHACL_CLASS)
+      .map((target) => target.object)
+      .map(extractStrippedName);
+
+    const noTargets = [
+      targetSubjects,
+      targetObjects,
+      targetClasses,
+      targetNodes,
+      classes,
+      targetPaths,
+    ].every((arr) => arr.length === 0);
 
     return noTargets
       ? [extractStrippedName(subject.value)]
-      : [...new Set([...targetClasses, ...targetNodes, ...targetSubjects, ...targetObjects])];
+      : [
+          ...new Set([
+            ...targetClasses,
+            ...targetNodes,
+            ...targetSubjects,
+            ...targetObjects,
+            ...targetPaths,
+            ...classes,
+          ]),
+        ];
   }
 }

--- a/src/json-schema/converters/constraints/constraint-converter.test.ts
+++ b/src/json-schema/converters/constraints/constraint-converter.test.ts
@@ -487,7 +487,6 @@ describe('ConstraintConverter', () => {
         context: mockContext,
         dependentsProcessed: false,
         isRoot: false,
-        isLogicalFragment: false,
       };
 
       processedMap.set(referencedShape, referencedElement);

--- a/src/json-schema/converters/constraints/constraint-converter.ts
+++ b/src/json-schema/converters/constraints/constraint-converter.ts
@@ -242,21 +242,29 @@ export class ConstraintConverter {
             .must(isNotNull)
             .allOf(arraySetByContext)
             .ifSatisfied((candidate: ConstraintCandidate) => {
+              const nodeKey = candidate.constraints.qualifiedValueShape ?? '';
+              const shape = [...this.processed.keys()].find((sh) => sh.nodeKey.endsWith(nodeKey));
+              const element = shape ? this.processed.get(shape) : undefined;
               const existingItems = builder.getKey('items') as JsonSchemaObjectType;
-              const ref = new JsonSchemaObjectBuilder()
-                .$ref(
-                  `#/$defs/${extractStrippedName(candidate.constraints.qualifiedValueShape ?? '')}`
-                )
-                .build();
+              const itemSchema = element?.shape.nodeKey.includes('n3')
+                ? element.builder.build()
+                : new JsonSchemaObjectBuilder()
+                    .$ref(`#/$defs/${extractStrippedName(nodeKey)}`)
+                    .build();
               builder.items({
                 ...existingItems,
-                ...ref,
+                ...itemSchema,
               });
             })
             .otherwise((candidate: ConstraintCandidate) => {
-              builder.$ref(
-                `#/$defs/${extractStrippedName(candidate.constraints.qualifiedValueShape ?? '')}`
-              );
+              const nodeKey = candidate.constraints.qualifiedValueShape ?? '';
+              const shape = [...this.processed.keys()].find((sh) => sh.nodeKey.endsWith(nodeKey));
+              const element = shape ? this.processed.get(shape) : undefined;
+              if (element?.shape.nodeKey.includes('n3')) {
+                builder.mergeFrom(element.builder.build());
+              } else {
+                builder.$ref(`#/$defs/${extractStrippedName(nodeKey)}`);
+              }
             })
             .execute();
         })

--- a/src/json-schema/converters/constraints/conversion-context.ts
+++ b/src/json-schema/converters/constraints/conversion-context.ts
@@ -12,15 +12,17 @@ export class ConversionContext {
   constraints: CoreConstraints;
   isPrimitive: boolean;
   isInvalid = false;
+  isFragment: boolean;
 
   constructor(
-    private readonly shapeDefinition: ShapeDefinition,
-    private readonly isLogicalFragment = false
+    private readonly parentShape: ShapeDefinition,
+    private readonly dependentShape: ShapeDefinition
   ) {
-    this.constraints = shapeDefinition.coreConstraints ?? {};
+    this.constraints = dependentShape.coreConstraints ?? {};
     this.isPrimitive = this.hasPrimitiveElements();
     this.isInvalid = this.checkForInvalidNumericConstraint();
-    if (!this.isLogicalFragment) {
+    this.isFragment = this.checkIsFragment();
+    if (!this.isFragment) {
       this.needToBeArray();
     }
   }
@@ -36,6 +38,19 @@ export class ConversionContext {
       .anyOf(
         (c) => c.minInclusive != null && c.maxInclusive != null && c.maxInclusive < c.minInclusive
       )
+      .execute();
+  }
+
+  checkIsFragment(): boolean {
+    const childNodeKey = this.dependentShape.nodeKey;
+    return new Condition()
+      .on(this.parentShape.coreConstraints)
+      .must((constraints) => constraints != null)
+      .anyOf((constraints) => constraints?.or?.some((ref) => ref.includes(childNodeKey)) ?? false)
+      .anyOf((constraints) => constraints?.and?.some((ref) => ref.includes(childNodeKey)) ?? false)
+      .anyOf((constraints) => constraints?.xone?.some((ref) => ref.includes(childNodeKey)) ?? false)
+      .anyOf((constraints) => constraints?.qualifiedValueShape?.includes(childNodeKey) ?? false)
+      .anyOf((constraints) => constraints?.not?.includes(childNodeKey) ?? false)
       .execute();
   }
 

--- a/src/json-schema/converters/shape-converter.ts
+++ b/src/json-schema/converters/shape-converter.ts
@@ -28,6 +28,13 @@ export class ShapeConverter {
     const propertyBuilder = JsonSchemaObjectBuilder.from(schema);
     new ShapeMetadataConverter(this.shape, this.options).applyToBuilder(propertyBuilder);
     const schemaWithMetadata = propertyBuilder.build();
+
+    // For fragments (logical or ref), don't create property structure - just merge schema
+    if (this.sb.isFragment()) {
+      this.builder.mergeFrom(schemaWithMetadata);
+      return;
+    }
+
     const possibleTargets = this.shape.targets;
     if (possibleTargets.length > 0) {
       const target = possibleTargets[0];

--- a/src/json-schema/ir-schema-converter-refs.test.ts
+++ b/src/json-schema/ir-schema-converter-refs.test.ts
@@ -1,0 +1,653 @@
+import { IrSchemaConverter } from './ir-schema-converter';
+import {
+  IntermediateRepresentation,
+  IntermediateRepresentationBuilder,
+} from '../ir/intermediate-representation-builder';
+import { ShaclParser } from '../shacl/parser/shacl-parser';
+
+async function getIr(content: string): Promise<IntermediateRepresentation> {
+  const shaclDocument = await new ShaclParser().withContent(content).parse();
+  return new IntermediateRepresentationBuilder(shaclDocument).build();
+}
+
+describe('IR Schema Converter - $refs', () => {
+  describe('qualifiedValueShape with blank nodes', () => {
+    it('should inline blank node schema with sh:class constraint', async () => {
+      const shacl = `
+        @prefix ex:  <http://example.org/> .
+        @prefix sh:  <http://www.w3.org/ns/shacl#> .
+
+        ex:TeamShape
+            a              sh:NodeShape ;
+            sh:targetClass ex:Team ;
+            sh:property    [ sh:path                ex:member ;
+                             sh:qualifiedValueShape [ sh:class ex:Person ] ;
+                             sh:qualifiedMinCount   1 ;
+                             sh:qualifiedMaxCount   5 ] .
+      `;
+
+      const ir = await getIr(shacl);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toMatchObject({
+        $defs: {
+          Team: {
+            properties: {
+              member: {
+                type: 'array',
+                items: {
+                  $ref: '#/$defs/Person',
+                },
+                minItems: 1,
+                maxItems: 5,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('should inline blank node schema with sh:class and nested property constraints (single value)', async () => {
+      const shacl = `
+        @prefix ex:  <http://example.org/> .
+        @prefix sh:  <http://www.w3.org/ns/shacl#> .
+
+        ex:TeamShape
+            a              sh:NodeShape ;
+            sh:targetClass ex:Team ;
+            sh:property    [ sh:path                ex:leader ;
+                             sh:qualifiedValueShape [ sh:class    ex:Person ;
+                                                      sh:property [ sh:path     ex:role ;
+                                                                    sh:hasValue "Leader" ] ] ;
+                             sh:qualifiedMinCount   1 ;
+                             sh:qualifiedMaxCount   1 ] .
+      `;
+
+      const ir = await getIr(shacl);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toMatchObject({
+        $defs: {
+          Team: {
+            properties: {
+              leader: {
+                $ref: '#/$defs/Person',
+                properties: {
+                  role: {
+                    const: 'Leader',
+                  },
+                },
+              },
+            },
+            required: ['leader'],
+          },
+        },
+      });
+    });
+
+    it('should inline blank node schema with multiple nested property constraints', async () => {
+      const shacl = `
+        @prefix ex:  <http://example.org/> .
+        @prefix sh:  <http://www.w3.org/ns/shacl#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:ProjectShape
+            a              sh:NodeShape ;
+            sh:targetClass ex:Project ;
+            sh:property    [ sh:path                ex:manager ;
+                             sh:qualifiedValueShape [ sh:class    ex:Employee ;
+                                                      sh:property [ sh:path     ex:level ;
+                                                                    sh:hasValue "Senior" ] ;
+                                                      sh:property [ sh:path     ex:department ;
+                                                                    sh:minCount 1 ] ] ;
+                             sh:qualifiedMinCount   1 ] .
+      `;
+
+      const ir = await getIr(shacl);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toMatchObject({
+        $defs: {
+          Project: {
+            properties: {
+              manager: {
+                type: 'array',
+                items: {
+                  $ref: '#/$defs/Employee',
+                  properties: {
+                    level: {
+                      const: 'Senior',
+                    },
+                    department: {},
+                  },
+                },
+                minItems: 1,
+              },
+            },
+            required: ['manager'],
+          },
+        },
+      });
+    });
+  });
+
+  describe('sh:class references', () => {
+    it('should generate $ref for sh:class in array context', async () => {
+      const shacl = `
+        @prefix ex:  <http://example.org/> .
+        @prefix sh:  <http://www.w3.org/ns/shacl#> .
+
+        ex:CompanyShape
+            a              sh:NodeShape ;
+            sh:targetClass ex:Company ;
+            sh:property    [ sh:path     ex:employees ;
+                             sh:class    ex:Employee ;
+                             sh:minCount 1 ] .
+      `;
+
+      const ir = await getIr(shacl);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toMatchObject({
+        $defs: {
+          Company: {
+            properties: {
+              employees: {
+                type: 'array',
+                items: {
+                  $ref: '#/$defs/Employee',
+                },
+                minItems: 1,
+              },
+            },
+            required: ['employees'],
+          },
+        },
+      });
+    });
+
+    it('should generate $ref for sh:class in non-array context', async () => {
+      const shacl = `
+        @prefix ex:  <http://example.org/> .
+        @prefix sh:  <http://www.w3.org/ns/shacl#> .
+
+        ex:OrderShape
+            a              sh:NodeShape ;
+            sh:targetClass ex:Order ;
+            sh:property    [ sh:path     ex:customer ;
+                             sh:class    ex:Customer ;
+                             sh:minCount 1 ;
+                             sh:maxCount 1 ] .
+      `;
+
+      const ir = await getIr(shacl);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toMatchObject({
+        $defs: {
+          Order: {
+            properties: {
+              customer: {
+                $ref: '#/$defs/Customer',
+              },
+            },
+            required: ['customer'],
+          },
+        },
+      });
+    });
+  });
+
+  describe('sh:node references', () => {
+    it('should generate $ref for sh:node to named shape', async () => {
+      const shacl = `
+        @prefix ex:  <http://example.org/> .
+        @prefix sh:  <http://www.w3.org/ns/shacl#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:AddressShape
+            a              sh:NodeShape ;
+            sh:targetClass ex:Address ;
+            sh:property    [ sh:path     ex:street ;
+                             sh:datatype xsd:string ] .
+
+        ex:PersonShape
+            a              sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property    [ sh:path     ex:address ;
+                             sh:node     ex:AddressShape ;
+                             sh:minCount 1 ;
+                             sh:maxCount 1 ] .
+      `;
+
+      const ir = await getIr(shacl);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toMatchObject({
+        $defs: {
+          Person: {
+            properties: {
+              address: {
+                $ref: '#/$defs/Address',
+              },
+            },
+            required: ['address'],
+          },
+        },
+      });
+    });
+
+    it('should generate $ref for sh:node in array context', async () => {
+      const shacl = `
+        @prefix ex:  <http://example.org/> .
+        @prefix sh:  <http://www.w3.org/ns/shacl#> .
+
+        ex:ItemShape
+            a              sh:NodeShape ;
+            sh:targetClass ex:Item .
+
+        ex:CartShape
+            a              sh:NodeShape ;
+            sh:targetClass ex:Cart ;
+            sh:property    [ sh:path     ex:items ;
+                             sh:node     ex:ItemShape ;
+                             sh:minCount 1 ] .
+      `;
+
+      const ir = await getIr(shacl);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      // Note: $ref uses the targetClass name (Item), not the shape name (ItemShape)
+      expect(schema).toMatchObject({
+        $defs: {
+          Cart: {
+            properties: {
+              items: {
+                type: 'array',
+                items: {
+                  $ref: '#/$defs/Item',
+                },
+                minItems: 1,
+              },
+            },
+            required: ['items'],
+          },
+        },
+      });
+    });
+  });
+
+  describe('logical constraints with $refs', () => {
+    it('should use $ref for named shapes in sh:or', async () => {
+      const shacl = `
+        @prefix ex:  <http://example.org/> .
+        @prefix sh:  <http://www.w3.org/ns/shacl#> .
+
+        ex:CatShape a sh:NodeShape ; sh:targetClass ex:Cat .
+        ex:DogShape a sh:NodeShape ; sh:targetClass ex:Dog .
+
+        ex:PetOwnerShape
+            a              sh:NodeShape ;
+            sh:targetClass ex:PetOwner ;
+            sh:property    [ sh:path ex:pet ;
+                             sh:or   ( ex:CatShape ex:DogShape ) ] .
+      `;
+
+      const ir = await getIr(shacl);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      // Note: $ref uses the targetClass names (Cat, Dog), not the shape names
+      expect(schema).toMatchObject({
+        $defs: {
+          PetOwner: {
+            properties: {
+              pet: {
+                anyOf: [{ $ref: '#/$defs/Cat' }, { $ref: '#/$defs/Dog' }],
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('should inline blank node schemas in sh:or', async () => {
+      const shacl = `
+        @prefix ex:  <http://example.org/> .
+        @prefix sh:  <http://www.w3.org/ns/shacl#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:ContactShape
+            a              sh:NodeShape ;
+            sh:targetClass ex:Contact ;
+            sh:property    [ sh:path ex:identifier ;
+                             sh:or   ( [ sh:datatype xsd:string ; sh:pattern "^[a-z]+$" ]
+                                       [ sh:datatype xsd:integer ] ) ] .
+      `;
+
+      const ir = await getIr(shacl);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toMatchObject({
+        $defs: {
+          Contact: {
+            properties: {
+              identifier: {
+                anyOf: [{ type: 'string', pattern: '^[a-z]+$' }, { type: 'integer' }],
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('should use $ref for named shapes in sh:and', async () => {
+      const shacl = `
+        @prefix ex:  <http://example.org/> .
+        @prefix sh:  <http://www.w3.org/ns/shacl#> .
+
+        ex:NamedShape a sh:NodeShape ; sh:targetClass ex:Named .
+        ex:AgedShape  a sh:NodeShape ; sh:targetClass ex:Aged .
+
+        ex:PersonShape
+            a              sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:and         ( ex:NamedShape ex:AgedShape ) .
+      `;
+
+      const ir = await getIr(shacl);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      // Note: $ref uses the targetClass names (Named, Aged), not the shape names
+      expect(schema).toMatchObject({
+        $defs: {
+          Person: {
+            allOf: [{ $ref: '#/$defs/Named' }, { $ref: '#/$defs/Aged' }],
+          },
+        },
+      });
+    });
+
+    it('should inline blank node schemas in sh:and', async () => {
+      const shacl = `
+        @prefix ex:  <http://example.org/> .
+        @prefix sh:  <http://www.w3.org/ns/shacl#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:ProductShape
+            a              sh:NodeShape ;
+            sh:targetClass ex:Product ;
+            sh:and         ( [ sh:property [ sh:path ex:name ; sh:minCount 1 ] ]
+                             [ sh:property [ sh:path ex:price ; sh:datatype xsd:decimal ] ] ) .
+      `;
+
+      const ir = await getIr(shacl);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toMatchObject({
+        $defs: {
+          Product: {
+            allOf: [
+              { properties: { name: {} }, required: ['name'] },
+              { properties: { price: { type: 'number' } } },
+            ],
+          },
+        },
+      });
+    });
+
+    it('should use $ref for named shapes in sh:xone', async () => {
+      const shacl = `
+        @prefix ex:  <http://example.org/> .
+        @prefix sh:  <http://www.w3.org/ns/shacl#> .
+
+        ex:CreditCardShape  a sh:NodeShape ; sh:targetClass ex:CreditCard .
+        ex:BankTransferShape a sh:NodeShape ; sh:targetClass ex:BankTransfer .
+
+        ex:PaymentShape
+            a              sh:NodeShape ;
+            sh:targetClass ex:Payment ;
+            sh:xone        ( ex:CreditCardShape ex:BankTransferShape ) .
+      `;
+
+      const ir = await getIr(shacl);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      // Note: $ref uses the targetClass names
+      expect(schema).toMatchObject({
+        $defs: {
+          Payment: {
+            oneOf: [{ $ref: '#/$defs/CreditCard' }, { $ref: '#/$defs/BankTransfer' }],
+          },
+        },
+      });
+    });
+
+    it('should use $ref for named shape in sh:not', async () => {
+      const shacl = `
+        @prefix ex:  <http://example.org/> .
+        @prefix sh:  <http://www.w3.org/ns/shacl#> .
+
+        ex:RestrictedShape a sh:NodeShape ; sh:targetClass ex:Restricted .
+
+        ex:OpenShape
+            a              sh:NodeShape ;
+            sh:targetClass ex:Open ;
+            sh:not         ex:RestrictedShape .
+      `;
+
+      const ir = await getIr(shacl);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      // Note: $ref uses the targetClass name
+      expect(schema).toMatchObject({
+        $defs: {
+          Open: {
+            not: { $ref: '#/$defs/Restricted' },
+          },
+        },
+      });
+    });
+
+    it('should inline blank node schema in sh:not with numeric value', async () => {
+      const shacl = `
+        @prefix ex:  <http://example.org/> .
+        @prefix sh:  <http://www.w3.org/ns/shacl#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:NonZeroShape
+            a              sh:NodeShape ;
+            sh:targetClass ex:NonZero ;
+            sh:property    [ sh:path ex:value ;
+                             sh:not  [ sh:hasValue 0 ] ] .
+      `;
+
+      const ir = await getIr(shacl);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      expect(schema).toMatchObject({
+        $defs: {
+          NonZero: {
+            properties: {
+              value: {
+                not: { const: 0 },
+              },
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe('deeply nested blank nodes', () => {
+    it('should handle multiple levels of nested blank nodes', async () => {
+      const shacl = `
+        @prefix ex:  <http://example.org/> .
+        @prefix sh:  <http://www.w3.org/ns/shacl#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:OrganizationShape
+            a              sh:NodeShape ;
+            sh:targetClass ex:Organization ;
+            sh:property    [ sh:path                ex:department ;
+                             sh:qualifiedValueShape [ sh:class    ex:Department ;
+                                                      sh:property [ sh:path                ex:head ;
+                                                                    sh:qualifiedValueShape [ sh:class    ex:Employee ;
+                                                                                             sh:property [ sh:path     ex:title ;
+                                                                                                           sh:hasValue "Director" ] ] ;
+                                                                    sh:qualifiedMinCount   1 ;
+                                                                    sh:qualifiedMaxCount   1 ] ] ;
+                             sh:qualifiedMinCount   1 ] .
+      `;
+
+      const ir = await getIr(shacl);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      // Note: With maxCount=1, the nested head is a single value, not an array
+      expect(schema).toMatchObject({
+        $defs: {
+          Organization: {
+            properties: {
+              department: {
+                type: 'array',
+                items: {
+                  $ref: '#/$defs/Department',
+                  properties: {
+                    head: {
+                      $ref: '#/$defs/Employee',
+                      properties: {
+                        title: {
+                          const: 'Director',
+                        },
+                      },
+                    },
+                  },
+                },
+                minItems: 1,
+              },
+            },
+            required: ['department'],
+          },
+        },
+      });
+    });
+
+    it('should handle deeply nested arrays with logical constraints', async () => {
+      // This creates paths like: $defs/University/properties/faculties/items/properties/courses/items/...
+      const shacl = `
+        @prefix ex:  <http://example.org/> .
+        @prefix sh:  <http://www.w3.org/ns/shacl#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:UniversityShape
+            a              sh:NodeShape ;
+            sh:targetClass ex:University ;
+            sh:property    [ sh:path     ex:faculties ;
+                             sh:minCount 1 ;
+                             sh:qualifiedValueShape [
+                                 sh:class    ex:Faculty ;
+                                 sh:property [ sh:path     ex:courses ;
+                                               sh:minCount 1 ;
+                                               sh:qualifiedValueShape [
+                                                   sh:class    ex:Course ;
+                                                   sh:property [ sh:path     ex:students ;
+                                                                 sh:minCount 1 ;
+                                                                 sh:qualifiedValueShape [
+                                                                     sh:class    ex:Student ;
+                                                                     sh:property [ sh:path     ex:grades ;
+                                                                                   sh:minCount 1 ;
+                                                                                   sh:or ( [ sh:datatype xsd:integer ;
+                                                                                             sh:minInclusive 0 ;
+                                                                                             sh:maxInclusive 100 ]
+                                                                                           [ sh:datatype xsd:string ;
+                                                                                             sh:pattern "^[A-F][+-]?$" ] ) ] ] ;
+                                                                 sh:qualifiedMinCount 1 ] ] ;
+                                                   sh:qualifiedMinCount 1 ] ] ;
+                             sh:qualifiedMinCount 1 ] .
+      `;
+
+      const ir = await getIr(shacl);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      // Deep nesting: University -> faculties[] -> courses[] -> students[] -> grades with anyOf
+      expect(schema).toMatchObject({
+        $defs: {
+          University: {
+            properties: {
+              faculties: {
+                type: 'array',
+                minItems: 1,
+                items: {
+                  $ref: '#/$defs/Faculty',
+                  properties: {
+                    courses: {
+                      type: 'array',
+                      minItems: 1,
+                      items: {
+                        $ref: '#/$defs/Course',
+                        properties: {
+                          students: {
+                            type: 'array',
+                            minItems: 1,
+                            items: {
+                              $ref: '#/$defs/Student',
+                              properties: {
+                                grades: {
+                                  type: 'array',
+                                  minItems: 1,
+                                  anyOf: [
+                                    { type: 'integer', minimum: 0, maximum: 100 },
+                                    { type: 'string', pattern: '^[A-F][+-]?$' },
+                                  ],
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            required: ['faculties'],
+          },
+        },
+      });
+    });
+  });
+
+  describe('mixed named and blank node references', () => {
+    it('should handle sh:or with mixed named shapes and blank nodes', async () => {
+      const shacl = `
+        @prefix ex:  <http://example.org/> .
+        @prefix sh:  <http://www.w3.org/ns/shacl#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        ex:EmailShape a sh:NodeShape ; sh:targetClass ex:Email .
+
+        ex:ContactInfoShape
+            a              sh:NodeShape ;
+            sh:targetClass ex:ContactInfo ;
+            sh:property    [ sh:path ex:contact ;
+                             sh:or   ( ex:EmailShape
+                                       [ sh:datatype xsd:string ; sh:pattern "^\\\\+[0-9]+$" ] ) ] .
+      `;
+
+      const ir = await getIr(shacl);
+      const schema = new IrSchemaConverter(ir).convert();
+
+      // Note: $ref uses the targetClass name (Email), not the shape name
+      expect(schema).toMatchObject({
+        $defs: {
+          ContactInfo: {
+            properties: {
+              contact: {
+                anyOf: [{ $ref: '#/$defs/Email' }, { type: 'string', pattern: '^\\+[0-9]+$' }],
+              },
+            },
+          },
+        },
+      });
+    });
+  });
+});

--- a/src/json-schema/ir-schema-converter.ts
+++ b/src/json-schema/ir-schema-converter.ts
@@ -10,7 +10,6 @@ import { StackElement } from '../stack/stack-element';
 import { StackElementBuilder } from '../stack/stack-element-builder';
 import { ShapeMetadataConverter } from './converters/shape-metadata-converter';
 import { ConstraintConverter } from './converters/constraints/constraint-converter';
-import { Condition } from '../condition/condition';
 import { ShaclDocument } from '../shacl/shacl-document';
 import { ConversionOptions } from './conversion-options';
 import mergeAllOf from 'json-schema-merge-allof';
@@ -87,17 +86,6 @@ export class IrSchemaConverter {
     return baseBuilder.build();
   }
 
-  private isLogicalConstraintFragment(parentShape: ShapeDefinition, childNodeKey: string): boolean {
-    return new Condition()
-      .on(parentShape.coreConstraints)
-      .must((constraints) => constraints != null)
-      .anyOf((constraints) => constraints?.or?.some((ref) => ref.includes(childNodeKey)) ?? false)
-      .anyOf((constraints) => constraints?.and?.some((ref) => ref.includes(childNodeKey)) ?? false)
-      .anyOf((constraints) => constraints?.xone?.some((ref) => ref.includes(childNodeKey)) ?? false)
-      .anyOf((constraints) => constraints?.not?.includes(childNodeKey) ?? false)
-      .execute();
-  }
-
   private processBottomUp(shapeDef: ShapeDefinition): JsonSchemaObjectType {
     const stack = new Stack();
     stack.push(new StackElementBuilder().shape(shapeDef).isRoot(true));
@@ -113,15 +101,10 @@ export class IrSchemaConverter {
   private addDependentShapes(stack: Stack, sb: StackElementBuilder) {
     stack.toggle(sb);
     sb.getShape().dependentShapes?.forEach((dependentShape) => {
-      const isLogicalFragment = this.isLogicalConstraintFragment(
-        sb.getShape(),
-        dependentShape.nodeKey
-      );
       stack.push(
         new StackElementBuilder()
           .shape(dependentShape)
-          .context(new ConversionContext(dependentShape, isLogicalFragment))
-          .isLogicalFragment(isLogicalFragment)
+          .context(new ConversionContext(sb.getShape(), dependentShape))
       );
     });
   }
@@ -150,7 +133,7 @@ export class IrSchemaConverter {
     top.getShape().dependentShapes?.forEach((dependentShape) => {
       const dependent = this.processed.get(dependentShape);
       if (dependent != null) {
-        if (dependent.isLogicalFragment) return;
+        if (dependent.context.isFragment) return;
         top.getBuilder().deepMerge(dependent.builder.build());
         if (dependent.context.required) {
           top.getBuilder().requiredElement(dependent.shape.targets[0]);

--- a/src/stack/stack-element-builder.test.ts
+++ b/src/stack/stack-element-builder.test.ts
@@ -18,8 +18,7 @@ describe('StackElementBuilder', () => {
         .shape(shape)
         .dependentsProcessed(true)
         .builder(jsonSchemaBuilder)
-        .isRoot(true)
-        .isLogicalFragment(false);
+        .isRoot(true);
 
       expect(result).toBe(builder);
     });
@@ -33,14 +32,12 @@ describe('StackElementBuilder', () => {
         .dependentsProcessed(true)
         .builder(jsonSchemaBuilder)
         .isRoot(true)
-        .isLogicalFragment(false)
         .build();
 
       expect(element.shape).toBe(shape);
       expect(element.dependentsProcessed).toBe(true);
       expect(element.builder).toBe(jsonSchemaBuilder);
       expect(element.isRoot).toBe(true);
-      expect(element.isLogicalFragment).toBe(false);
     });
   });
 
@@ -85,13 +82,6 @@ describe('StackElementBuilder', () => {
       const element = builder.build();
 
       expect(element.dependentsProcessed).toBe(false);
-    });
-
-    it('should use default false for isLogicalFragment when called without argument', () => {
-      builder.isLogicalFragment();
-      const element = builder.build();
-
-      expect(element.isLogicalFragment).toBe(false);
     });
 
     it('should use default false for isRoot when called without argument', () => {

--- a/src/stack/stack-element-builder.ts
+++ b/src/stack/stack-element-builder.ts
@@ -27,13 +27,8 @@ export class StackElementBuilder {
     return this;
   }
 
-  context(_context = new ConversionContext(this.stackElement.shape)) {
+  context(_context = new ConversionContext(this.stackElement.shape, { nodeKey: '', targets: [] })) {
     this.stackElement.context = _context;
-    return this;
-  }
-
-  isLogicalFragment(_isLogicalFragment = false) {
-    this.stackElement.isLogicalFragment = _isLogicalFragment;
     return this;
   }
 
@@ -54,8 +49,8 @@ export class StackElementBuilder {
     return this.stackElement.dependentsProcessed;
   }
 
-  getLogicalFragment() {
-    return this.stackElement.isLogicalFragment;
+  isFragment() {
+    return this.stackElement.context.isFragment;
   }
 
   getBuilder() {

--- a/src/stack/stack-element.ts
+++ b/src/stack/stack-element.ts
@@ -8,5 +8,4 @@ export interface StackElement {
   builder: JsonSchemaObjectBuilder;
   context: ConversionContext;
   isRoot: boolean;
-  isLogicalFragment: boolean;
 }

--- a/src/stack/stack.test.ts
+++ b/src/stack/stack.test.ts
@@ -18,7 +18,6 @@ describe('Stack', () => {
       expect(defaultElement.builder).toBeDefined();
       expect(defaultElement.context).toBeDefined();
       expect(defaultElement.isRoot).toBe(false);
-      expect(defaultElement.isLogicalFragment).toBe(false);
     });
   });
 

--- a/src/stack/stack.ts
+++ b/src/stack/stack.ts
@@ -12,9 +12,11 @@ export class Stack {
       shape: new ShapeDefinitionBuilder('').build(),
       dependentsProcessed: false,
       builder: new JsonSchemaObjectBuilder(),
-      context: new ConversionContext(new ShapeDefinitionBuilder('').build()),
+      context: new ConversionContext(
+        new ShapeDefinitionBuilder('').build(),
+        new ShapeDefinitionBuilder('').build()
+      ),
       isRoot: false,
-      isLogicalFragment: false,
     };
   }
 


### PR DESCRIPTION
## Description

- Fix possible blank node in $refs

Fixes #83 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

- Allow target resolver to resolve targets for blank nodes
- Add `sh:class` as a possible target
- Modify code to allow for inlined schema for `sh:qualifiedValueShape`
- Move fragment resolution to conversion context

## Testing

Please describe the tests you ran to verify your changes:

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality
- [x] Tested manually with sample SHACL files

## Checklist

- [x] My code follows the project's code style
- [x] I have run `npm run fix:lint-format`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings