### PR TITLE
fix(shacl): filter out non shapes included as shapes

### DIFF
--- a/src/ir/indexer.test.ts
+++ b/src/ir/indexer.test.ts
@@ -195,7 +195,9 @@ describe('Indexer', () => {
       const subject1 = 'http://example.org/Subject1';
       const subject2 = 'http://example.org/Subject2';
       const content = await new StoreBuilder()
+        .shape(subject1, SHACL_NODE_SHAPE)
         .triple(subject1, SHACL_NAME, 'First', false)
+        .shape(subject2, SHACL_NODE_SHAPE)
         .triple(subject2, SHACL_NAME, 'Second', false)
         .write();
       const shaclDocument = await new ShaclParser().withContent(content).parse();
@@ -242,6 +244,7 @@ describe('Indexer', () => {
     it('should handle RDF list nodes as blank nodes', async () => {
       const shape = 'http://example.org/PersonShape';
       const content = await new StoreBuilder()
+        .shape(shape, SHACL_NODE_SHAPE)
         .triple(shape, SHACL_IGNORED_PROPERTIES, 'l1', true)
         .blank('l1', RDF_FIRST, RDF_TYPE)
         .blank('l2', RDF_FIRST, 'http://example.org/customProp')

--- a/src/ir/indexer.ts
+++ b/src/ir/indexer.ts
@@ -19,7 +19,7 @@ export class Indexer {
 
   build(): Index {
     const quads = getQuads(this.shaclDocument);
-    const shapes = getShapes(this.shaclDocument.subjects);
+    const shapes = getShapes(this.shaclDocument);
     const targets = this.targetResolver.resolveTargets(quads);
     return {
       quads: quads,

--- a/src/ir/target-resolver.test.ts
+++ b/src/ir/target-resolver.test.ts
@@ -5,7 +5,7 @@ import { getQuads, getShapes } from './util';
 async function getShapesAndQuads(content: string) {
   const shaclDocument = await new ShaclParser().withContent(content).parse();
   const quads = getQuads(shaclDocument);
-  const shapes = getShapes(shaclDocument.subjects);
+  const shapes = getShapes(shaclDocument);
   return { quads, shapes, shaclDocument };
 }
 

--- a/src/ir/util.ts
+++ b/src/ir/util.ts
@@ -1,6 +1,24 @@
 import { BlankNode, Quad_Subject, Term, Util } from 'n3';
 import { ShaclDocument } from '../shacl/shacl-document';
+import {
+  RDF_TYPE,
+  SHACL_NODE_SHAPE,
+  SHACL_PATH,
+  SHACL_PROPERTY_SHAPE,
+  SHACL_TARGET_CLASS,
+  SHACL_TARGET_NODE,
+  SHACL_TARGET_OBJECTS_OF,
+  SHACL_TARGET_SUBJECTS_OF,
+} from '../shacl/shacl-terms';
 import isBlankNode = Util.isBlankNode;
+
+const SHAPE_TARGET_PREDICATES = [
+  SHACL_TARGET_CLASS,
+  SHACL_TARGET_NODE,
+  SHACL_TARGET_SUBJECTS_OF,
+  SHACL_TARGET_OBJECTS_OF,
+  SHACL_PATH,
+];
 
 export function getQuads(shaclDocument: ShaclDocument) {
   const { subjects, store, graphId } = shaclDocument;
@@ -13,6 +31,17 @@ export function getBlankNodes(subjects: Term[]): BlankNode[] {
   return [...new Set(subjects.filter((subject) => isBlankNode(subject)))];
 }
 
-export function getShapes(subjects: Term[]): Quad_Subject[] {
-  return [...new Set(subjects.filter((subject) => !isBlankNode(subject)))] as Quad_Subject[];
+export function getShapes(shaclDocument: ShaclDocument): Quad_Subject[] {
+  const { store, graphId, subjects } = shaclDocument;
+  const shapeValues = new Set<string>();
+  store.getSubjects(RDF_TYPE, SHACL_NODE_SHAPE, graphId).forEach((s) => shapeValues.add(s.value));
+  store
+    .getSubjects(RDF_TYPE, SHACL_PROPERTY_SHAPE, graphId)
+    .forEach((s) => shapeValues.add(s.value));
+  SHAPE_TARGET_PREDICATES.map((predicate) => store.getSubjects(predicate, null, graphId))
+    .flatMap((subjects) => [...subjects])
+    .forEach((subject) => shapeValues.add(subject.value));
+  return subjects
+    .filter((s) => !isBlankNode(s))
+    .filter((s) => shapeValues.has(s.value)) as Quad_Subject[];
 }


### PR DESCRIPTION
## Description

Non-shape resources included as shapes are included as shapes in the processing pipeline leading to invalid shapes

Fixes #100 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement

## Changes Made

- Add better resolution for subjects by explicitly restricting to specific SHACL keywords 

## Testing

Please describe the tests you ran to verify your changes:

- [x] Existing tests pass (`npm test`)
- [ ] Added new tests for new functionality
- [ ] Tested manually with sample SHACL files

## Checklist

- [x] My code follows the project's code style
- [x] I have run `npm run fix:lint-format`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings