### PR TITLE
fix(compare): move to f1 score

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,40 +68,40 @@ shacl-bridge to-shacl -i input.json --base-uri http://example.org/shapes/
 #### Compare SHACL Files
 
 ```bash
-# Compare two SHACL files and print a similarity score with differences
-shacl-bridge compare --file1 schema-v1.ttl --file2 schema-v2.ttl
+# Compare two SHACL files and print precision, recall, and F1 with differences
+shacl-bridge compare --expected schema-v1.ttl --actual schema-v2.ttl
 
 # Shorten URIs in the diff output using prefixes from the input files
-shacl-bridge compare --file1 schema-v1.ttl --file2 schema-v2.ttl --shorten
+shacl-bridge compare --expected schema-v1.ttl --actual schema-v2.ttl --shorten
 ```
 
 Example output:
 
 ```
-Score: 0.7143 (71.4% similar)
+Precision: 0.8000  Recall: 0.6667  F1: 0.7273
 
-Only in schema-v1.ttl:
+Only in expected (schema-v1.ttl):
   [http://example.org/PersonShape]
     <http://example.org/PersonShape> <http://www.w3.org/ns/shacl#property> _:c14n0 .
     _:c14n0 <http://www.w3.org/ns/shacl#minCount> "1" .
 
-Only in schema-v2.ttl:
+Only in actual (schema-v2.ttl):
   [http://example.org/PersonShape]
     <http://example.org/PersonShape> <http://www.w3.org/ns/shacl#property> _:c14n0 .
     _:c14n0 <http://www.w3.org/ns/shacl#minCount> "2" .
 ```
 
-The similarity score is computed using [Jaccard similarity](https://en.wikipedia.org/wiki/Jaccard_index) on the
-canonicalized RDF triples of both files (via URDNA2015). Blank nodes are assigned deterministic labels based on their
-structural context, so structurally identical property shapes compare as equal regardless of their original blank node
-identifiers.
+Metrics are computed on the canonicalized RDF triples of both files (via RDFC-1.0). Blank nodes are assigned
+deterministic labels based on their structural context, so structurally identical property shapes compare as equal
+regardless of their original blank node identifiers. `--expected` is the reference (ground truth) and `--actual` is
+the file being evaluated.
 
 #### Command Options
 
 ##### `to-json-schema`
 
 | Option                       | Description                                                             |
-| ---------------------------- | ----------------------------------------------------------------------- |
+|------------------------------|-------------------------------------------------------------------------|
 | `-i, --input <file>`         | SHACL file to convert (Turtle or JSON-LD)                               |
 | `-o, --output <file>`        | Output file (single mode) or directory (multi mode)                     |
 | `--from-clipboard`           | Read SHACL content from clipboard                                       |
@@ -114,7 +114,7 @@ identifiers.
 ##### `to-shacl`
 
 | Option                | Description                             |
-| --------------------- | --------------------------------------- |
+|-----------------------|-----------------------------------------|
 | `-i, --input <file>`  | JSON Schema file to convert             |
 | `-o, --output <file>` | Output file for SHACL                   |
 | `--from-clipboard`    | Read JSON Schema content from clipboard |
@@ -123,11 +123,11 @@ identifiers.
 
 ##### `compare`
 
-| Option           | Description                                            |
-| ---------------- | ------------------------------------------------------ |
-| `--file1 <file>` | First SHACL file to compare (Turtle, required)         |
-| `--file2 <file>` | Second SHACL file to compare (Turtle, required)        |
-| `--shorten`      | Shorten URIs in diff output using prefixes from inputs |
+| Option              | Description                                            |
+|---------------------|--------------------------------------------------------|
+| `--expected <file>` | Expected (reference) SHACL file (Turtle, required)     |
+| `--actual <file>`   | Actual (predicted) SHACL file (Turtle, required)       |
+| `--shorten`         | Shorten URIs in diff output using prefixes from inputs |
 
 #### Output Modes (to-json-schema)
 
@@ -144,7 +144,7 @@ The `--mode` (`-m`) option controls how the JSON Schema output is structured:
 - Comprehensive SHACL constraint support
 - Automatic blank node resolution
 - Multi-file output mode for modular schemas
-- SHACL document comparison with Jaccard similarity scoring and triple-level diff
+- SHACL document comparison with precision/recall/F1 scoring and triple-level diff
 
 ### Programmatic API
 
@@ -157,7 +157,7 @@ npm install shacl-bridge
 #### SHACL to JSON Schema
 
 ```typescript
-import { ShaclReader } from 'shacl-bridge';
+import {ShaclReader} from 'shacl-bridge';
 
 // Convert from Turtle file
 const jsonSchema = await new ShaclReader().fromPath('input.ttl').convert();
@@ -173,37 +173,37 @@ const jsonSchema = await new ShaclReader().fromJsonLdContent(jsonLdString).conve
 
 // With options (exclude x-shacl-* extensions)
 const jsonSchema = await new ShaclReader()
-  .fromPath('input.ttl')
-  .withOptions({ includeShaclExtensions: true })
-  .convert();
+        .fromPath('input.ttl')
+        .withOptions({includeShaclExtensions: true})
+        .convert();
 ```
 
 #### JSON Schema to SHACL
 
 ```typescript
-import { ShaclWriter, DEFAULT_PREFIXES } from 'shacl-bridge';
+import {ShaclWriter, DEFAULT_PREFIXES} from 'shacl-bridge';
 
 const jsonSchema = {
-  $id: 'http://example.org/PersonShape',
-  type: 'object',
-  properties: {
-    name: { type: 'string', minLength: 1 },
-    age: { type: 'integer', minimum: 0 },
-  },
-  required: ['name'],
+    $id: 'http://example.org/PersonShape',
+    type: 'object',
+    properties: {
+        name: {type: 'string', minLength: 1},
+        age: {type: 'integer', minimum: 0},
+    },
+    required: ['name'],
 };
 
 // Convert to Turtle
 const turtle = await new ShaclWriter(jsonSchema)
-  .getStoreBuilder()
-  .withPrefixes({ ...DEFAULT_PREFIXES, ex: 'http://example.org/' })
-  .write();
+    .getStoreBuilder()
+    .withPrefixes({...DEFAULT_PREFIXES, ex: 'http://example.org/'})
+    .write();
 
 // Convert to JSON-LD
 const jsonLd = await new ShaclWriter(jsonSchema)
-  .getStoreBuilder()
-  .withPrefixes({ ...DEFAULT_PREFIXES, ex: 'http://example.org/' })
-  .writeJsonLd();
+    .getStoreBuilder()
+    .withPrefixes({...DEFAULT_PREFIXES, ex: 'http://example.org/'})
+    .writeJsonLd();
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ the file being evaluated.
 ##### `to-json-schema`
 
 | Option                       | Description                                                             |
-|------------------------------|-------------------------------------------------------------------------|
+| ---------------------------- | ----------------------------------------------------------------------- |
 | `-i, --input <file>`         | SHACL file to convert (Turtle or JSON-LD)                               |
 | `-o, --output <file>`        | Output file (single mode) or directory (multi mode)                     |
 | `--from-clipboard`           | Read SHACL content from clipboard                                       |
@@ -114,7 +114,7 @@ the file being evaluated.
 ##### `to-shacl`
 
 | Option                | Description                             |
-|-----------------------|-----------------------------------------|
+| --------------------- | --------------------------------------- |
 | `-i, --input <file>`  | JSON Schema file to convert             |
 | `-o, --output <file>` | Output file for SHACL                   |
 | `--from-clipboard`    | Read JSON Schema content from clipboard |
@@ -124,7 +124,7 @@ the file being evaluated.
 ##### `compare`
 
 | Option              | Description                                            |
-|---------------------|--------------------------------------------------------|
+| ------------------- | ------------------------------------------------------ |
 | `--expected <file>` | Expected (reference) SHACL file (Turtle, required)     |
 | `--actual <file>`   | Actual (predicted) SHACL file (Turtle, required)       |
 | `--shorten`         | Shorten URIs in diff output using prefixes from inputs |
@@ -157,7 +157,7 @@ npm install shacl-bridge
 #### SHACL to JSON Schema
 
 ```typescript
-import {ShaclReader} from 'shacl-bridge';
+import { ShaclReader } from 'shacl-bridge';
 
 // Convert from Turtle file
 const jsonSchema = await new ShaclReader().fromPath('input.ttl').convert();
@@ -173,37 +173,37 @@ const jsonSchema = await new ShaclReader().fromJsonLdContent(jsonLdString).conve
 
 // With options (exclude x-shacl-* extensions)
 const jsonSchema = await new ShaclReader()
-        .fromPath('input.ttl')
-        .withOptions({includeShaclExtensions: true})
-        .convert();
+  .fromPath('input.ttl')
+  .withOptions({ includeShaclExtensions: true })
+  .convert();
 ```
 
 #### JSON Schema to SHACL
 
 ```typescript
-import {ShaclWriter, DEFAULT_PREFIXES} from 'shacl-bridge';
+import { ShaclWriter, DEFAULT_PREFIXES } from 'shacl-bridge';
 
 const jsonSchema = {
-    $id: 'http://example.org/PersonShape',
-    type: 'object',
-    properties: {
-        name: {type: 'string', minLength: 1},
-        age: {type: 'integer', minimum: 0},
-    },
-    required: ['name'],
+  $id: 'http://example.org/PersonShape',
+  type: 'object',
+  properties: {
+    name: { type: 'string', minLength: 1 },
+    age: { type: 'integer', minimum: 0 },
+  },
+  required: ['name'],
 };
 
 // Convert to Turtle
 const turtle = await new ShaclWriter(jsonSchema)
-    .getStoreBuilder()
-    .withPrefixes({...DEFAULT_PREFIXES, ex: 'http://example.org/'})
-    .write();
+  .getStoreBuilder()
+  .withPrefixes({ ...DEFAULT_PREFIXES, ex: 'http://example.org/' })
+  .write();
 
 // Convert to JSON-LD
 const jsonLd = await new ShaclWriter(jsonSchema)
-    .getStoreBuilder()
-    .withPrefixes({...DEFAULT_PREFIXES, ex: 'http://example.org/'})
-    .writeJsonLd();
+  .getStoreBuilder()
+  .withPrefixes({ ...DEFAULT_PREFIXES, ex: 'http://example.org/' })
+  .writeJsonLd();
 ```
 
 ## Development

--- a/benchmark/run-benchmark.ts
+++ b/benchmark/run-benchmark.ts
@@ -57,13 +57,13 @@ function toJsonSchema(ttlFile: string, outFile: string): boolean {
   }
 }
 
-function compareShacl(file1: string, file2: string): string {
+function compareShacl(expected: string, actual: string): string {
   try {
-    const output = execSync(`${SHACL_BRIDGE} compare --file1 "${file1}" --file2 "${file2}"`, {
-      encoding: 'utf8',
-      stdio: 'pipe',
-    });
-    const match = /^Score:\s+(\S+)/m.exec(output);
+    const output = execSync(
+      `${SHACL_BRIDGE} compare --expected "${expected}" --actual "${actual}"`,
+      { encoding: 'utf8', stdio: 'pipe' }
+    );
+    const match = /F1:\s+(\S+)/m.exec(output);
     return match ? match[1] : 'N/A';
   } catch {
     return 'N/A';

--- a/cli-tests/cli-tests-windows.ps1
+++ b/cli-tests/cli-tests-windows.ps1
@@ -566,7 +566,7 @@ try {
     Write-Host ""
     Write-Host "Test 27: compare --help flag"
     $compareHelp = shacl-bridge compare --help
-    if ($compareHelp -like "*compare*" -and $compareHelp -like "*--file1*" -and $compareHelp -like "*--file2*")
+    if ($compareHelp -like "*compare*" -and $compareHelp -like "*--expected*" -and $compareHelp -like "*--actual*")
     {
         Write-Host "compare help output is valid" -ForegroundColor Green
     }
@@ -578,57 +578,57 @@ try {
 
     Write-Host ""
     Write-Host "Test 28: compare two different SHACL files"
-    $compareOutput = shacl-bridge compare --file1 samples/shacl/simple-shacl.ttl --file2 samples/shacl/cardinality-constraints.ttl
+    $compareOutput = shacl-bridge compare --expected samples/shacl/simple-shacl.ttl --actual samples/shacl/cardinality-constraints.ttl
     if ($LASTEXITCODE -ne 0)
     {
         throw "compare command failed"
     }
     $compareString = $compareOutput -join "`n"
-    if ($compareString -like "*Score:*")
+    if ($compareString -like "*F1:*")
     {
-        Write-Host "compare produces score output" -ForegroundColor Green
+        Write-Host "compare produces F1 output" -ForegroundColor Green
         Write-Host "  Output: $( $compareOutput | Select-Object -First 1 )"
     }
     else
     {
-        Write-Host "compare output missing Score" -ForegroundColor Red
+        Write-Host "compare output missing F1" -ForegroundColor Red
         exit 1
     }
 
     Write-Host ""
-    Write-Host "Test 29: compare a file to itself should yield 100% similarity"
-    $sameFileOutput = shacl-bridge compare --file1 samples/shacl/simple-shacl.ttl --file2 samples/shacl/simple-shacl.ttl
+    Write-Host "Test 29: compare a file to itself should yield F1=1"
+    $sameFileOutput = shacl-bridge compare --expected samples/shacl/simple-shacl.ttl --actual samples/shacl/simple-shacl.ttl
     if ($LASTEXITCODE -ne 0)
     {
         throw "same-file compare failed"
     }
     $sameFileString = $sameFileOutput -join "`n"
-    if ($sameFileString -like "*100.0%*")
+    if ($sameFileString -like "*F1: 1.0000*")
     {
-        Write-Host "Same-file comparison correctly yields 100% similarity" -ForegroundColor Green
+        Write-Host "Same-file comparison correctly yields F1=1" -ForegroundColor Green
     }
     else
     {
-        Write-Host "Same-file comparison did not yield 100% similarity" -ForegroundColor Red
+        Write-Host "Same-file comparison did not yield F1=1" -ForegroundColor Red
         Write-Host "  Output: $sameFileString"
         exit 1
     }
 
     Write-Host ""
     Write-Host "Test 30: compare with --shorten flag produces prefixed output"
-    $shortenOutput = shacl-bridge compare --file1 samples/shacl/simple-shacl.ttl --file2 samples/shacl/cardinality-constraints.ttl --shorten
+    $shortenOutput = shacl-bridge compare --expected samples/shacl/simple-shacl.ttl --actual samples/shacl/cardinality-constraints.ttl --shorten
     if ($LASTEXITCODE -ne 0)
     {
         throw "compare --shorten failed"
     }
     $shortenString = $shortenOutput -join "`n"
-    if ($shortenString -like "*Score:*")
+    if ($shortenString -like "*F1:*")
     {
         Write-Host "compare --shorten produces valid output" -ForegroundColor Green
     }
     else
     {
-        Write-Host "compare --shorten output missing Score" -ForegroundColor Red
+        Write-Host "compare --shorten output missing F1" -ForegroundColor Red
         exit 1
     }
 
@@ -637,14 +637,14 @@ try {
     shacl-bridge compare 2> $null
     if ($LASTEXITCODE -eq 0)
     {
-        Write-Host "Should have failed without --file1 and --file2" -ForegroundColor Red
+        Write-Host "Should have failed without --expected and --actual" -ForegroundColor Red
         exit 1
     }
-    Write-Host "Correctly requires --file1 and --file2 flags" -ForegroundColor Green
+    Write-Host "Correctly requires --expected and --actual flags" -ForegroundColor Green
 
     Write-Host ""
     Write-Host "Test 32: compare with nonexistent file should fail"
-    shacl-bridge compare --file1 nonexistent.ttl --file2 samples/shacl/simple-shacl.ttl 2> $null
+    shacl-bridge compare --expected nonexistent.ttl --actual samples/shacl/simple-shacl.ttl 2> $null
     if ($LASTEXITCODE -eq 0)
     {
         Write-Host "Should have failed with nonexistent file" -ForegroundColor Red

--- a/cli-tests/cli-tests.sh
+++ b/cli-tests/cli-tests.sh
@@ -447,7 +447,7 @@ echo "=== Compare Tests ==="
 echo ""
 echo "Test 27: compare --help flag"
 COMPARE_HELP=$(shacl-bridge compare --help)
-if [[ $COMPARE_HELP == *"compare"* ]] && [[ $COMPARE_HELP == *"--file1"* ]] && [[ $COMPARE_HELP == *"--file2"* ]]; then
+if [[ $COMPARE_HELP == *"compare"* ]] && [[ $COMPARE_HELP == *"--expected"* ]] && [[ $COMPARE_HELP == *"--actual"* ]]; then
     echo -e "${GREEN}compare help output is valid${NC}"
 else
     echo -e "${RED}compare help output is invalid${NC}"
@@ -456,47 +456,47 @@ fi
 
 echo ""
 echo "Test 28: compare two different SHACL files"
-COMPARE_OUTPUT=$(shacl-bridge compare --file1 samples/shacl/simple-shacl.ttl --file2 samples/shacl/cardinality-constraints.ttl)
-if [[ $COMPARE_OUTPUT == *"Score:"* ]]; then
-    echo -e "${GREEN}compare produces score output${NC}"
+COMPARE_OUTPUT=$(shacl-bridge compare --expected samples/shacl/simple-shacl.ttl --actual samples/shacl/cardinality-constraints.ttl)
+if [[ $COMPARE_OUTPUT == *"F1:"* ]]; then
+    echo -e "${GREEN}compare produces F1 output${NC}"
     echo "  Output: $(echo "$COMPARE_OUTPUT" | head -1)"
 else
-    echo -e "${RED}compare output missing Score${NC}"
+    echo -e "${RED}compare output missing F1${NC}"
     exit 1
 fi
 
 echo ""
-echo "Test 29: compare a file to itself should yield 100% similarity"
-SAME_FILE_OUTPUT=$(shacl-bridge compare --file1 samples/shacl/simple-shacl.ttl --file2 samples/shacl/simple-shacl.ttl)
-if [[ $SAME_FILE_OUTPUT == *"100.0%"* ]]; then
-    echo -e "${GREEN}Same-file comparison correctly yields 100% similarity${NC}"
+echo "Test 29: compare a file to itself should yield F1=1"
+SAME_FILE_OUTPUT=$(shacl-bridge compare --expected samples/shacl/simple-shacl.ttl --actual samples/shacl/simple-shacl.ttl)
+if [[ $SAME_FILE_OUTPUT == *"F1: 1.0000"* ]]; then
+    echo -e "${GREEN}Same-file comparison correctly yields F1=1${NC}"
 else
-    echo -e "${RED}Same-file comparison did not yield 100% similarity${NC}"
+    echo -e "${RED}Same-file comparison did not yield F1=1${NC}"
     echo "  Output: $SAME_FILE_OUTPUT"
     exit 1
 fi
 
 echo ""
 echo "Test 30: compare with --shorten flag produces prefixed output"
-SHORTEN_OUTPUT=$(shacl-bridge compare --file1 samples/shacl/simple-shacl.ttl --file2 samples/shacl/cardinality-constraints.ttl --shorten)
-if [[ $SHORTEN_OUTPUT == *"Score:"* ]]; then
+SHORTEN_OUTPUT=$(shacl-bridge compare --expected samples/shacl/simple-shacl.ttl --actual samples/shacl/cardinality-constraints.ttl --shorten)
+if [[ $SHORTEN_OUTPUT == *"F1:"* ]]; then
     echo -e "${GREEN}compare --shorten produces valid output${NC}"
 else
-    echo -e "${RED}compare --shorten output missing Score${NC}"
+    echo -e "${RED}compare --shorten output missing F1${NC}"
     exit 1
 fi
 
 echo ""
 echo "Test 31: compare without required flags should fail"
 if shacl-bridge compare 2>/dev/null; then
-    echo -e "${RED}Should have failed without --file1 and --file2${NC}"
+    echo -e "${RED}Should have failed without --expected and --actual${NC}"
     exit 1
 fi
-echo -e "${GREEN}Correctly requires --file1 and --file2 flags${NC}"
+echo -e "${GREEN}Correctly requires --expected and --actual flags${NC}"
 
 echo ""
 echo "Test 32: compare with nonexistent file should fail"
-if shacl-bridge compare --file1 nonexistent.ttl --file2 samples/shacl/simple-shacl.ttl 2>/dev/null; then
+if shacl-bridge compare --expected nonexistent.ttl --actual samples/shacl/simple-shacl.ttl 2>/dev/null; then
     echo -e "${RED}Should have failed with nonexistent file${NC}"
     exit 1
 fi

--- a/src/cli/cli-constants.ts
+++ b/src/cli/cli-constants.ts
@@ -81,21 +81,21 @@ export const TO_JSON_SCHEMA = {
 };
 
 export interface CompareOptions {
-  file1: string;
-  file2: string;
+  expected: string;
+  actual: string;
   shorten: boolean;
 }
 
 export const COMPARE = {
   command: 'compare',
-  description: 'Compare two SHACL files and output a similarity score with differences',
-  file1: {
-    flag: '--file1 <file>',
-    description: 'First SHACL file (Turtle)',
+  description: 'Compare two SHACL files and output precision, recall, and F1 with differences',
+  expected: {
+    flag: '--expected <file>',
+    description: 'Expected (reference) SHACL file (Turtle)',
   },
-  file2: {
-    flag: '--file2 <file>',
-    description: 'Second SHACL file (Turtle)',
+  actual: {
+    flag: '--actual <file>',
+    description: 'Actual (predicted) SHACL file (Turtle)',
   },
   shorten: {
     flag: '--shorten',

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -84,8 +84,8 @@ const toShaclCommand = new Command(TO_SHACL.command)
 const compareCommand = new Command(COMPARE.command)
   .description(COMPARE.description)
   .showHelpAfterError(true)
-  .requiredOption(COMPARE.file1.flag, COMPARE.file1.description)
-  .requiredOption(COMPARE.file2.flag, COMPARE.file2.description)
+  .requiredOption(COMPARE.expected.flag, COMPARE.expected.description)
+  .requiredOption(COMPARE.actual.flag, COMPARE.actual.description)
   .option(COMPARE.shorten.flag, COMPARE.shorten.description, COMPARE.shorten.default)
   .action(async function (this: Command, options: CompareOptions) {
     try {

--- a/src/cli/shacl-compare.ts
+++ b/src/cli/shacl-compare.ts
@@ -9,41 +9,42 @@ export class ShaclCompare {
   constructor(private readonly options: CompareOptions) {}
 
   async compare(): Promise<void> {
-    const { file1, file2, shorten } = this.options;
+    const { expected, actual, shorten } = this.options;
 
-    if (!fs.existsSync(file1)) throw new Error(`File not found: ${file1}`);
-    if (!fs.existsSync(file2)) throw new Error(`File not found: ${file2}`);
+    if (!fs.existsSync(expected)) throw new Error(`File not found: ${expected}`);
+    if (!fs.existsSync(actual)) throw new Error(`File not found: ${actual}`);
 
-    const result = await new ShaclComparator(file1, file2).compare();
+    const result = await new ShaclComparator(expected, actual).compare();
 
-    const prefixes = shorten ? await this.collectPrefixes(file1, file2) : {};
+    const prefixes = shorten ? await this.collectPrefixes(expected, actual) : {};
     const format = (triple: string) => (shorten ? applyPrefixes(triple, prefixes) : triple);
 
-    const scorePercent = (result.score * 100).toFixed(1);
-    console.log(`Score: ${result.score.toFixed(4)} (${scorePercent}% similar)\n`);
+    console.log(
+      `Precision: ${result.precision.toFixed(4)}  Recall: ${result.recall.toFixed(4)}  F1: ${result.f1.toFixed(4)}\n`
+    );
 
-    if (result.onlyInFile1.length === 0 && result.onlyInFile2.length === 0) {
+    if (result.onlyInExpected.length === 0 && result.onlyInActual.length === 0) {
       console.log('Files are identical.');
       return;
     }
 
-    if (result.onlyInFile1.length > 0) {
-      console.log(`Only in ${file1}:`);
-      printGroups(result.onlyInFile1, format);
+    if (result.onlyInExpected.length > 0) {
+      console.log(`Only in expected (${expected}):`);
+      printGroups(result.onlyInExpected, format);
     }
 
-    if (result.onlyInFile2.length > 0) {
-      console.log(`Only in ${file2}:`);
-      printGroups(result.onlyInFile2, format);
+    if (result.onlyInActual.length > 0) {
+      console.log(`Only in actual (${actual}):`);
+      printGroups(result.onlyInActual, format);
     }
   }
 
-  private async collectPrefixes(file1: string, file2: string): Promise<Prefixes> {
-    const [doc1, doc2] = await Promise.all([
-      new ShaclParser().withPath(file1).parse(),
-      new ShaclParser().withPath(file2).parse(),
+  private async collectPrefixes(expected: string, actual: string): Promise<Prefixes> {
+    const [docExpected, docActual] = await Promise.all([
+      new ShaclParser().withPath(expected).parse(),
+      new ShaclParser().withPath(actual).parse(),
     ]);
-    return { ...doc1.prefix, ...doc2.prefix };
+    return { ...docExpected.prefix, ...docActual.prefix };
   }
 }
 

--- a/src/compare/shacl-comparator.ts
+++ b/src/compare/shacl-comparator.ts
@@ -27,27 +27,32 @@ function groupBySubject(triples: Set<string>): TripleDiff[] {
 
 export class ShaclComparator {
   constructor(
-    private readonly file1: string,
-    private readonly file2: string
+    private readonly expected: string,
+    private readonly actual: string
   ) {}
 
   async compare(): Promise<ComparisonResult> {
-    const [doc1, doc2] = await Promise.all([
-      new ShaclParser().withPath(this.file1).parse(),
-      new ShaclParser().withPath(this.file2).parse(),
+    const [docExpected, docActual] = await Promise.all([
+      new ShaclParser().withPath(this.expected).parse(),
+      new ShaclParser().withPath(this.actual).parse(),
     ]);
 
-    const [set1, set2] = await Promise.all([
-      canonicalizeStore(doc1.store),
-      canonicalizeStore(doc2.store),
+    const [setExpected, setActual] = await Promise.all([
+      canonicalizeStore(docExpected.store),
+      canonicalizeStore(docActual.store),
     ]);
 
-    const { onlyInA, onlyInB, score } = computeDiff(set1, set2);
+    const { onlyInExpected, onlyInActual, precision, recall, f1 } = computeDiff(
+      setExpected,
+      setActual
+    );
 
     return {
-      score,
-      onlyInFile1: groupBySubject(onlyInA),
-      onlyInFile2: groupBySubject(onlyInB),
+      precision,
+      recall,
+      f1,
+      onlyInExpected: groupBySubject(onlyInExpected),
+      onlyInActual: groupBySubject(onlyInActual),
     };
   }
 }

--- a/src/compare/triple-diff.ts
+++ b/src/compare/triple-diff.ts
@@ -1,13 +1,22 @@
 export interface SetDiff {
-  onlyInA: Set<string>;
-  onlyInB: Set<string>;
-  score: number;
+  onlyInExpected: Set<string>;
+  onlyInActual: Set<string>;
+  precision: number;
+  recall: number;
+  f1: number;
 }
 
-export function computeDiff(a: Set<string>, b: Set<string>): SetDiff {
-  const onlyInA = new Set([...a].filter((x) => !b.has(x)));
-  const onlyInB = new Set([...b].filter((x) => !a.has(x)));
-  const unionSize = new Set([...a, ...b]).size;
-  const score = unionSize === 0 ? 1 : (unionSize - onlyInA.size - onlyInB.size) / unionSize;
-  return { onlyInA, onlyInB, score };
+export function computeDiff(expected: Set<string>, actual: Set<string>): SetDiff {
+  const onlyInExpected = new Set([...expected].filter((x) => !actual.has(x)));
+  const onlyInActual = new Set([...actual].filter((x) => !expected.has(x)));
+  const tp = expected.size - onlyInExpected.size;
+  const precision = actual.size > 0 ? tp / actual.size : 0;
+  const recall = expected.size > 0 ? tp / expected.size : 0;
+  const f1 =
+    expected.size === 0 && actual.size === 0
+      ? 1
+      : precision + recall > 0
+        ? (2 * precision * recall) / (precision + recall)
+        : 0;
+  return { onlyInExpected, onlyInActual, precision, recall, f1 };
 }

--- a/src/compare/types.ts
+++ b/src/compare/types.ts
@@ -4,7 +4,9 @@ export interface TripleDiff {
 }
 
 export interface ComparisonResult {
-  score: number;
-  onlyInFile1: TripleDiff[];
-  onlyInFile2: TripleDiff[];
+  precision: number;
+  recall: number;
+  f1: number;
+  onlyInExpected: TripleDiff[];
+  onlyInActual: TripleDiff[];
 }

--- a/test/compare/shacl-comparator.integration.test.ts
+++ b/test/compare/shacl-comparator.integration.test.ts
@@ -4,39 +4,39 @@ const SIMPLE = 'samples/shacl/simple-shacl.ttl';
 const CARDINALITY = 'samples/shacl/cardinality-constraints.ttl';
 
 describe('ShaclComparator', () => {
-  it('returns score 1 and empty diffs when comparing a file to itself', async () => {
+  it('returns f1=1 and empty diffs when comparing a file to itself', async () => {
     const result = await new ShaclComparator(SIMPLE, SIMPLE).compare();
-    expect(result.score).toBe(1);
-    expect(result.onlyInFile1).toHaveLength(0);
-    expect(result.onlyInFile2).toHaveLength(0);
+    expect(result.f1).toBe(1);
+    expect(result.onlyInExpected).toHaveLength(0);
+    expect(result.onlyInActual).toHaveLength(0);
   });
 
-  it('returns score 0 and non-empty diffs for completely different files', async () => {
+  it('returns f1<1 and non-empty diffs for completely different files', async () => {
     const result = await new ShaclComparator(SIMPLE, CARDINALITY).compare();
-    expect(result.score).toBe(0);
-    expect(result.onlyInFile1.length).toBeGreaterThan(0);
-    expect(result.onlyInFile2.length).toBeGreaterThan(0);
+    expect(result.f1).toBeLessThan(1);
+    expect(result.onlyInExpected.length).toBeGreaterThan(0);
+    expect(result.onlyInActual.length).toBeGreaterThan(0);
   });
 
-  it('onlyInFile1 groups are non-empty and subjects are non-empty strings', async () => {
+  it('onlyInExpected groups are non-empty and subjects are non-empty strings', async () => {
     const result = await new ShaclComparator(SIMPLE, CARDINALITY).compare();
-    for (const group of result.onlyInFile1) {
+    for (const group of result.onlyInExpected) {
       expect(group.subject).toBeTruthy();
       expect(group.triples.length).toBeGreaterThan(0);
     }
   });
 
-  it('onlyInFile2 groups are non-empty and subjects are non-empty strings', async () => {
+  it('onlyInActual groups are non-empty and subjects are non-empty strings', async () => {
     const result = await new ShaclComparator(SIMPLE, CARDINALITY).compare();
-    for (const group of result.onlyInFile2) {
+    for (const group of result.onlyInActual) {
       expect(group.subject).toBeTruthy();
       expect(group.triples.length).toBeGreaterThan(0);
     }
   });
 
-  it('is symmetric in score', async () => {
+  it('f1 is symmetric', async () => {
     const r1 = await new ShaclComparator(SIMPLE, CARDINALITY).compare();
     const r2 = await new ShaclComparator(CARDINALITY, SIMPLE).compare();
-    expect(r1.score).toBeCloseTo(r2.score);
+    expect(r1.f1).toBeCloseTo(r2.f1);
   });
 });

--- a/test/compare/triple-diff.test.ts
+++ b/test/compare/triple-diff.test.ts
@@ -1,43 +1,45 @@
 import { computeDiff } from '../../src/compare/triple-diff';
 
 describe('computeDiff', () => {
-  it('returns score 1 and empty diffs for identical sets', () => {
+  it('returns f1=1 and empty diffs for identical sets', () => {
     const a = new Set(['triple1', 'triple2', 'triple3']);
     const result = computeDiff(a, new Set(a));
-    expect(result.score).toBe(1);
-    expect(result.onlyInA.size).toBe(0);
-    expect(result.onlyInB.size).toBe(0);
+    expect(result.f1).toBe(1);
+    expect(result.onlyInExpected.size).toBe(0);
+    expect(result.onlyInActual.size).toBe(0);
   });
 
-  it('returns score 0 and full diffs for completely disjoint sets', () => {
-    const a = new Set(['triple1', 'triple2']);
-    const b = new Set(['triple3', 'triple4']);
-    const result = computeDiff(a, b);
-    expect(result.score).toBe(0);
-    expect(result.onlyInA).toEqual(new Set(['triple1', 'triple2']));
-    expect(result.onlyInB).toEqual(new Set(['triple3', 'triple4']));
+  it('returns f1=0 and full diffs for completely disjoint sets', () => {
+    const expected = new Set(['triple1', 'triple2']);
+    const actual = new Set(['triple3', 'triple4']);
+    const result = computeDiff(expected, actual);
+    expect(result.f1).toBe(0);
+    expect(result.onlyInExpected).toEqual(new Set(['triple1', 'triple2']));
+    expect(result.onlyInActual).toEqual(new Set(['triple3', 'triple4']));
   });
 
-  it('computes correct Jaccard for partial overlap', () => {
-    // |A| = 3, |B| = 3, |A∩B| = 2, |A∪B| = 4, Jaccard = 2/4 = 0.5
-    const a = new Set(['t1', 't2', 't3']);
-    const b = new Set(['t2', 't3', 't4']);
-    const result = computeDiff(a, b);
-    expect(result.score).toBeCloseTo(0.5);
-    expect(result.onlyInA).toEqual(new Set(['t1']));
-    expect(result.onlyInB).toEqual(new Set(['t4']));
+  it('computes correct F1 for partial overlap', () => {
+    // expected={t1,t2,t3}, actual={t2,t3,t4}, tp=2, precision=2/3, recall=2/3, F1=2/3
+    const expected = new Set(['t1', 't2', 't3']);
+    const actual = new Set(['t2', 't3', 't4']);
+    const result = computeDiff(expected, actual);
+    expect(result.f1).toBeCloseTo(2 / 3);
+    expect(result.precision).toBeCloseTo(2 / 3);
+    expect(result.recall).toBeCloseTo(2 / 3);
+    expect(result.onlyInExpected).toEqual(new Set(['t1']));
+    expect(result.onlyInActual).toEqual(new Set(['t4']));
   });
 
-  it('returns score 1 for two empty sets', () => {
+  it('returns f1=1 for two empty sets', () => {
     const result = computeDiff(new Set(), new Set());
-    expect(result.score).toBe(1);
+    expect(result.f1).toBe(1);
   });
 
-  it('returns score 0 when one set is empty', () => {
-    const a = new Set(['t1', 't2']);
-    const result = computeDiff(a, new Set());
-    expect(result.score).toBe(0);
-    expect(result.onlyInA).toEqual(a);
-    expect(result.onlyInB.size).toBe(0);
+  it('returns f1=0 when actual is empty but expected is not', () => {
+    const expected = new Set(['t1', 't2']);
+    const result = computeDiff(expected, new Set());
+    expect(result.f1).toBe(0);
+    expect(result.onlyInExpected).toEqual(expected);
+    expect(result.onlyInActual.size).toBe(0);
   });
 });


### PR DESCRIPTION
## Description

- Move to precision, recall and f1-score instead of jaccard's similarity for SHACL comparison
- JSON Schema comparison for the benchmark uses f1 score, this change is to keep both comparisons consistent

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

- Move to f1 score

## Testing

Please describe the tests you ran to verify your changes:

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality
- [x] Tested manually with sample SHACL files

## Checklist

- [x] My code follows the project's code style
- [x] I have run `npm run fix:lint-format`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [x] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings